### PR TITLE
Fixing WCS bug 

### DIFF
--- a/astrophot/image/__init__.py
+++ b/astrophot/image/__init__.py
@@ -5,21 +5,4 @@ from .jacobian_image import *
 from .psf_image import *
 from .model_image import *
 from .window_object import *
-
-"""
-Import all the classes from the module.
-
-1st import: Imports classes for representing images with pixel values, pixel scale, and window coordinates on the sky. 
-            Supports arithmetic operations while preserving image boundaries and provides methods for 
-            determining pixel coordinates.
-
-2nd import: Imports an Image object representing data to be fit by a model, 
-            including ancillary data such as variance image, mask, and PSF that describe the target image.
-
-3rd import: Imports an Image object representing the sampling of a model at image coordinates. 
-            Provides arithmetic operations to update model values and allows sub-pixel shifts.
-
-4th import: Imports methods for defining windows on the sky in coordinate space. 
-            Windows can undergo arithmetic and preserve logical behavior. 
-            Image objects can be indexed using windows to return appropriate subsections of their data.
-"""
+from .wcs import *

--- a/astrophot/image/image_header.py
+++ b/astrophot/image/image_header.py
@@ -221,12 +221,12 @@ class Image_Header:
         self.window.crop_pixel(pixels)
         return self
 
-    def rescale(self, scale: int, **kwargs):
+    def rescale_pixel(self, scale: int, **kwargs):
         if scale == 1:
             return self
         
         return self.copy(
-            window = self.window.rescale(scale),
+            window = self.window.rescale_pixel(scale),
             **kwargs,
         )
     

--- a/astrophot/image/image_header.py
+++ b/astrophot/image/image_header.py
@@ -192,8 +192,8 @@ class Image_Header(WCS):
         else:
             # When the Window object is provided
             self.window = window
-            kwargs["reference_radec"] = window.reference_radec
-            kwargs["projection"] = window.projection
+            kwargs["reference_radec"] = kwargs.get("reference_radec", window.reference_radec)
+            kwargs["projection"] = kwargs.get("projection", window.projection)
             super().__init__(**kwargs)
             if self.pixelscale is None:
                 pixelscale = self.window.shape[0] / data_shape[1]
@@ -206,6 +206,12 @@ class Image_Header(WCS):
                     device=AP_config.ap_device,
                 )
 
+        self.check_wcs()
+        
+    def check_wcs(self):
+        assert self.projection == self.window.projection, "Image_Header and Widnow projection do not match!"
+        assert torch.allclose(self.reference_radec, self.window.reference_radec), "Image_Header and Window reference_radec do not match!"
+        
     @property
     def pixelscale(self):
         return self._pixelscale

--- a/astrophot/image/image_header.py
+++ b/astrophot/image/image_header.py
@@ -154,7 +154,7 @@ class Image_Header(WPCS):
                 center_radec is not None
             ):  # Image reference position from RA and DEC of image center
                 pix_center = torch.flip(
-                    data_shape.to(dtype=AP_config.ap_dtype),
+                    self.data_shape.to(dtype=AP_config.ap_dtype),
                     (0,),
                 ) / 2 - 0.5
 
@@ -177,7 +177,7 @@ class Image_Header(WPCS):
                 center is not None
             ):  # Image reference position from tangent plane position of image center
                 pix_center = torch.flip(
-                    data_shape.to(dtype=AP_config.ap_dtype),
+                    self.data_shape.to(dtype=AP_config.ap_dtype),
                     (0,),
                 ) / 2 - 0.5
                 self.reference_imageij = pix_center
@@ -598,10 +598,10 @@ class Image_Header(WPCS):
 
     def set_fits_state(self, state):
         super().set_fits_state(state)
-        self.pixelscale = eval(hdu.header.get("PXLSCALE"))
-        self.zeropoint = eval(hdu.header.get("ZEROPNT"))
-        self.note = hdu.header.get("NOTE")
-        self.window = Window(state=eval(hdu.header.get("WINDOW")))
+        self.pixelscale = eval(state["PXLSCALE"])
+        self.zeropoint = eval(state.get("ZEROPNT", "None"))
+        self.note = state.get("NOTE",None)
+        self.window = Window(state=eval(state["WINDOW"]))
         
     def save(self, filename=None, overwrite=True):
         image_list = self._save_image_list()

--- a/astrophot/image/image_header.py
+++ b/astrophot/image/image_header.py
@@ -42,7 +42,7 @@ class Image_Header:
         self,
         *,
         data_shape: Optional[torch.Tensor] = None,
-        wcs: Optional["astropy.wcs.wcs.WCS"] = None,
+        wcs: Optional["astropy.wcs.WCS"] = None,
         window: Optional[Window] = None,
         filename: Optional[str] = None,
         zeropoint: Optional[Union[float, torch.Tensor]] = None,

--- a/astrophot/image/image_header.py
+++ b/astrophot/image/image_header.py
@@ -138,7 +138,7 @@ class Image_Header(WCS):
                     device=AP_config.ap_device,
                 )
                 super().__init__(reference_radec=wcs_origin)
-                origin = self.world_to_plane(*wcs_origin)
+                origin = torch.stack(self.world_to_plane(*wcs_origin))
             elif (
                 origin_radec is not None
             ):  # Image reference position from RA and DEC of image origin
@@ -146,7 +146,7 @@ class Image_Header(WCS):
                     origin_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
                 )
                 super().__init__(reference_radec=origin_radec)
-                origin = self.world_to_plane(*origin_radec)
+                origin = torch.stack(self.world_to_plane(*origin_radec))
             elif (
                 center_radec is not None
             ):  # Image reference position from RA and DEC of image center
@@ -154,7 +154,7 @@ class Image_Header(WCS):
                     center_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
                 )
                 super().__init__(reference_radec=center_radec)
-                center = self.world_to_plane(*center_radec)
+                center = torch.stack(self.world_to_plane(*center_radec))
                 origin = center - end / 2
             elif (
                 origin is not None

--- a/astrophot/image/image_header.py
+++ b/astrophot/image/image_header.py
@@ -14,113 +14,39 @@ from .. import AP_config
 __all__ = ["Image_Header"]
 
 
-class Image_Header(WPCS):
+class Image_Header:
     """Store meta-information for images to be used in AstroPhot.
 
     The Image_Header object stores all meta information which tells
     AstroPhot what is contained in an image array of pixels. This
-    includes information about where the pixels are in the coordiante
-    systems and how to transform between them (see
+    includes coordinate systems and how to transform between them (see
     :doc:`coordiantes`). The image header will also know the image
     zeropoint if that data is avaialble.
-
-    There are several ways to tell an Image_Header object where to
-    place the pixels it stores. The simplest method is to pass an
-    Astropy WCS object such as::
-
-      H = ap.image.Image_Header(
-          data_shape = data.shape,
-          wcs = wcs,
-      )
-
-    this will automatically place your image at the correct RA, DEC
-    and assign the correct pixel scale. WARNING, it will default to
-    setting the reference RA DEC at the reference RA DEC of the wcs
-    object; if you have multiple images you should force them all to
-    have the same reference world coordiante by passing
-    ``reference_radec = (ra, dec)``. See the :doc:`coordinates`
-    documentation for more details. There are several other ways to
-    initialize the image header. If you provide ``origin_radec`` then
-    it will place the image origin at the requested RA DEC
-    coordinates. If you provide ``center_radec`` then it will place
-    the image center at the requested RA DEC coordiantes. Note that in
-    these cases the fixed point between the pixel grid and image plane
-    is different (pixel origin and center respectively); so if you
-    have rotated pixels in your pixel scale matrix then everything
-    will be rotated about different points (pixel origin and center
-    respectively). If you provide ``origin`` or ``center`` then those
-    are coordiantes in the tangent plane (arcsec) and they will
-    correspondingly become fixed points. For arbitrary control over
-    the pixel positioning, use ``reference_imageij`` and
-    ``reference_imagexy`` to fix the pixel and tangent plane
-    coordinates respectively to each other, any rotation or shear will
-    happen about that fixed point.
     
     Args:
-    pixelscale : float or None, optional
-        The physical scale of the pixels in the image, this is
-        represented as a matrix which projects pixel units into sky
-        units: :math:`pixelscale @ pixel_vec = sky_vec`. The pixel
-        scale matrix can be thought of in four components:
-        :math:`\vec{s} @ F @ R @ S` where :math:`\vec{s}` is the side
-        length of the pixels, :math:`F` is a diagonal matrix of {1,-1}
-        which flips the axes orientation, :math:`R` is a rotation
-        matrix, and :math:`S` is a shear matrix which turns
-        rectangular pixels into parallelograms. Default is None.
-    window : Window or None, optional
-        A Window object defining the area of the image on the tangent
-        plane to use. Default is None.
-    filename : str or None, optional
-        The name of a file containing the image data. Default is None.
-    zeropoint : float or None, optional
-        The image's zeropoint, used for flux calibration. Default is None.
-    note : str or None, optional
-        A note describing the image. Default is None.
-    origin : Sequence or None, optional
-        The origin of the image in the tangent plane coordinate system
-        (arcsec), as a 1D array of length 2. Default is None.
-    origin_radec : Sequence or None, optional
-        The origin of the image in the world coordinate system (RA,
-        DEC in degrees), as a 1D array of length 2. Default is None.
-    center : Sequence or None, optional
-        The center of the image in the tangent plane coordinate system
-        (arcsec), as a 1D array of length 2. Default is None.
-    center_radec : Sequence or None, optional
-        The center of the image in the world coordinate system (RA,
-        DEC in degrees), as a 1D array of length 2. Default is None.
-    reference_imageij : Sequence or None, optional
-        The pixel coordinate at which the image is fixed to the
-        tangent plane. By default this is (-0.5, -0.5) or the bottom
-        corner of the [0,0] indexed pixel.
-    reference_imagexy : Sequence or None, optional
-        The tangent plane coordinate at which the image is fixed,
-        corresponding to the reference_imageij coordinate. These two
-        reference points ar pinned together, any rotations would occur
-        about this point. By default this is (0., 0.).
+      window : Window or None, optional
+          A Window object defining the area of the image in the coordinate
+          systems. Default is None.
+      filename : str or None, optional
+          The name of a file containing the image data. Default is None.
+      zeropoint : float or None, optional
+          The image's zeropoint, used for flux calibration. Default is None.
+      note : str or None, optional
+          A note describing the image. Default is None.
     
     """
 
     north = np.pi / 2.
-    default_reference_imageij = (-0.5,-0.5)
-    default_reference_imagexy = (0,0)
-    default_pixelscale = 1
     
     def __init__(
         self,
-        data_shape: Optional[torch.Tensor],
         *,
-        pixelscale: Optional[Union[float, torch.Tensor]] = None,
+        data_shape: Optional[torch.Tensor] = None,
         wcs: Optional["astropy.wcs.wcs.WCS"] = None,
         window: Optional[Window] = None,
         filename: Optional[str] = None,
         zeropoint: Optional[Union[float, torch.Tensor]] = None,
         note: Optional[str] = None,
-        origin: Optional[Sequence] = None,
-        origin_radec: Optional[Sequence] = None,
-        center: Optional[Sequence] = None,
-        center_radec: Optional[Sequence] = None,
-        reference_imagexy: Optional[Sequence] = None,
-        reference_imageij: Optional[Sequence] = None,
         identity: str = None,
         **kwargs: Any,
     ) -> None:
@@ -134,315 +60,27 @@ class Image_Header(WPCS):
             self.load(filename)
             return
 
-        self.data_shape = torch.as_tensor(
-            data_shape, dtype=torch.int32, device=AP_config.ap_device
-        )
         # set Zeropoint
         self.zeropoint = zeropoint
 
         # set a note for the image
         self.note = note
-
-        if wcs is not None:
-            if wcs.wcs.ctype[0] != "RA---TAN":
-                AP_config.ap_logger.warn("Astropy WCS not tangent plane coordinate system!")
-            if wcs.wcs.ctype[1] != "DEC--TAN":
-                AP_config.ap_logger.warn("Astropy WCS not tangent plane coordinate system!")
-                
-        if wcs is not None and pixelscale is None:
-            self.pixelscale = deg_to_arcsec * wcs.pixel_scale_matrix
-        else:
-            if wcs is not None and isinstance(pixelscale, float):
-                AP_config.ap_logger.warn(
-                    "Overriding WCS pixelscale with manual input! To remove this message, either let WCS define pixelscale, or input full pixelscale matrix"
-                )
-            self.pixelscale = pixelscale
-
+        
         # Set Window
         if window is None:
-            # If window is not provided, create one based on pixelscale and data shape
-            assert (
-                self.pixelscale is not None
-            ), "pixelscale cannot be None if window is not provided"
-
-            end = self.pixel_to_plane_delta(
-                torch.flip(
-                    torch.tensor(
-                        data_shape, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-                    ),
-                    (0,),
-                )
+            data_shape = torch.as_tensor(
+                data_shape, dtype=torch.int32, device=AP_config.ap_device
             )
-            shape = torch.stack(
-                (
-                    torch.linalg.norm(
-                        self.pixel_to_plane_delta(
-                            torch.tensor(
-                                [data_shape[1], 0],
-                                dtype=AP_config.ap_dtype,
-                                device=AP_config.ap_device,
-                            )
-                        )
-                    ),
-                    torch.linalg.norm(
-                        self.pixel_to_plane_delta(
-                            torch.tensor(
-                                [0, data_shape[0]],
-                                dtype=AP_config.ap_dtype,
-                                device=AP_config.ap_device,
-                            )
-                        )
-                    ),
-                )
-            )
-            assert sum(C is not None for C in [wcs, origin_radec, center_radec, origin, center]) <= 1, "Please provide only one reference position for the image, otherwise the placement is ambiguous"
-            if wcs is not None:  # Image coordinates provided by WCS
-                kwargs["reference_radec"] = kwargs.get("reference_radec", wcs.wcs.crval)
-                super().__init__(**kwargs)
-                self.reference_imageij = wcs.wcs.crpix
-                self.reference_imagexy = torch.stack(self.world_to_plane(*torch.tensor(wcs.wcs.crval, dtype=AP_config.ap_dtype, device=AP_config.ap_device)))
-                origin = torch.stack(self.pixel_to_plane(*(-0.5 * torch.ones_like(self.reference_imageij))))
-            elif (
-                origin_radec is not None
-            ):  # Image reference position from RA and DEC of image origin
-                # Origin given, it is reference point
-                self.reference_imageij = (-0.5,-0.5)
-                origin_radec = torch.as_tensor(
-                    origin_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-                )
-                kwargs["reference_radec"] = kwargs.get("reference_radec", origin_radec)
-                super().__init__(**kwargs)
-                origin = torch.stack(self.world_to_plane(*origin_radec))
-                self.reference_imagexy = origin
-            elif (
-                center_radec is not None
-            ):  # Image reference position from RA and DEC of image center
-                pix_center = torch.flip(
-                    self.data_shape.to(dtype=AP_config.ap_dtype),
-                    (0,),
-                ) / 2 - 0.5
-
-                self.reference_imageij = pix_center
-                center_radec = torch.as_tensor(
-                    center_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-                )
-                kwargs["reference_radec"] = kwargs.get("reference_radec", center_radec)
-                super().__init__(**kwargs)
-                center = torch.stack(self.world_to_plane(*center_radec))
-                self.reference_imagexy = center
-                origin = self.pixel_to_plane(*(-0.5 * torch.ones_like(self.reference_imagexy)))
-            elif (
-                origin is not None
-            ):  # Image reference position from tangent plane position of image origin
-                self.reference_imageij = (-0.5,-0.5)
-                self.reference_imagexy = origin
-                super().__init__(**kwargs)
-            elif (
-                center is not None
-            ):  # Image reference position from tangent plane position of image center
-                pix_center = torch.flip(
-                    self.data_shape.to(dtype=AP_config.ap_dtype),
-                    (0,),
-                ) / 2 - 0.5
-                self.reference_imageij = pix_center
-                self.reference_imagexy = center
-                super().__init__(**kwargs)
-                origin = self.pixel_to_plane(*(-0.5 * torch.ones_like(self.reference_imagexy)))                
-            else:  # Image origin assumed to be at tangent plane origin
-                super().__init__(**kwargs)
-                self.reference_imageij = (-0.5,-0.5) if reference_imageij is None else reference_imageij
-                self.reference_imagexy = (0,0) if reference_imagexy is None else reference_imagexy
-                origin = self.pixel_to_plane(*(-0.5 * torch.ones_like(self.reference_imagexy)))
-
+            # If window is not provided, create one based on provided information
             self.window = Window(
-                origin=origin,
-                shape=shape,
-                pixelshape=self.pixelscale,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-                reference_planexy=self.reference_planexy,
+                pixel_shape=torch.flip(data_shape, (0,)),
+                wcs=wcs,
+                **kwargs,
             )
         else:
             # When the Window object is provided
             self.window = window
-            kwargs["reference_radec"] = window.reference_radec
-            kwargs["reference_planexy"] = window.reference_planexy
-            kwargs["projection"] = window.projection
-            super().__init__(**kwargs)
-            self.reference_imageij = (-0.5,-0.5) if reference_imageij is None else reference_imageij
-            self.reference_imagexy = window.origin if reference_imagexy is None else reference_imagexy
-            if self.pixelscale is None:
-                pixelscale = self.window.shape[0] / data_shape[1]
-                AP_config.ap_logger.warn(
-                    "Assuming square pixels with pixelscale f{pixelscale.item()}. To remove this warning please provide the pixelscale explicitly when creating an image."
-                )
-                self.pixelscale = torch.tensor(
-                    [[pixelscale, 0.0], [0.0, pixelscale]],
-                    dtype=AP_config.ap_dtype,
-                    device=AP_config.ap_device,
-                )
-        
-    @property
-    def pixelscale(self):
-        """Matrix defining the shape of pixels in the tangent plane, these
-        can be any parallelogram defined by the matrix.
-
-        """
-        return self._pixelscale
-
-    @pixelscale.setter
-    def pixelscale(self, pix):
-        if pix is None:
-            self._pixelscale = None
-            return
-
-        self._pixelscale = (
-            torch.as_tensor(pix, dtype=AP_config.ap_dtype, device=AP_config.ap_device)
-            .clone()
-            .detach()
-        )
-        if self._pixelscale.numel() == 1:
-            self._pixelscale = torch.tensor(
-                [[self._pixelscale.item(), 0.0], [0.0, self._pixelscale.item()]],
-                dtype=AP_config.ap_dtype,
-                device=AP_config.ap_device,
-            )
-        self._pixel_area = torch.linalg.det(self.pixelscale).abs()
-        self._pixel_length = self._pixel_area.sqrt()
-        self._pixelscale_inv = torch.linalg.inv(self.pixelscale)
-
-    @property
-    def pixel_area(self):
-        """The area inside a pixel in arcsec^2
-
-        """
-        return self._pixel_area
-
-    @property
-    def pixel_length(self):
-        """The approximate length of a pixel, which is just
-        sqrt(pixel_area). For square pixels this is the actual pixel
-        length, for rectangular pixels it is a kind of average.
-
-        The pixel_length is typically not used for exact calculations
-        and instead sets a size scale within an image.
-
-        """
-        return self._pixel_length
-
-    @property
-    def reference_imageij(self):
-        """pixel coordiantes where the pixel grid is fixed to the tangent
-        plane. These should be in pixel units where (0,0) is the
-        center of the [0,0] indexed pixel. However, it is still in xy
-        format, meaning that the first index gives translations in the
-        x-axis (horizontal-axis) of the image.
-
-        """
-        return self._reference_imageij
-
-    @reference_imageij.setter
-    def reference_imageij(self, imageij):
-        self._reference_imageij = torch.as_tensor(
-            imageij, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-    @property
-    def reference_imagexy(self):
-        """plane coordiantes where the image grid is fixed to the tangent
-        plane. These should be in arcsec.
-
-        """
-        return self._reference_imagexy
-
-    @reference_imagexy.setter
-    def reference_imagexy(self, imagexy):
-        self._reference_imagexy = torch.as_tensor(
-            imagexy, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-
-    def pixel_to_plane(self, pixel_i, pixel_j=None):
-        """Take in a coordinate on the regular pixel grid, where 0,0 is the
-        center of the [0,0] indexed pixel. This coordinate is
-        transformed into the tangent plane coordiante system (arcsec)
-        based on the pixel scale and reference positions. If the pixel
-        scale matrix is :math:`P`, the reference pixel is
-        :math:`\vec{r}_{pix}`, the reference tangent plane point is
-        :math:`\vec{r}_{tan}`, and the coordinate to transform is
-        :math:`\vec{c}_{pix}` then the coordiante in the tangent plane
-        is:
-
-        .. math::
-            \vec{c}_{tan} = [P(\vec{c}_{pix} - \vec{r}_{pix})] + \vec{r}_{tan}
-
-        """
-        if pixel_j is None:
-            return torch.stack(self.pixel_to_plane(*pixel_i))
-        coords = torch.mm(self.pixelscale, torch.stack((pixel_i.reshape(-1), pixel_j.reshape(-1))) - self.reference_imageij.view(2,1)) + self.reference_imagexy.view(2,1)
-        return coords[0].reshape(pixel_i.shape), coords[1].reshape(pixel_j.shape)
-
-    def plane_to_pixel(self, plane_x, plane_y=None):
-        """Take a coordinate on the tangent plane (arcsec) and transform it to
-        the cooresponding pixel grid coordinate (pixel units where
-        (0,0) is the [0,0] indexed pixel). Transformation is done
-        based on the pixel scale and reference positions. If the pixel
-        scale matrix is :math:`P`, the reference pixel is
-        :math:`\vec{r}_{pix}`, the reference tangent plane point is
-        :math:`\vec{r}_{tan}`, and the coordinate to transform is
-        :math:`\vec{c}_{tan}` then the coordiante in the pixel grid
-        is:
-
-        .. math::
-            \vec{c}_{pix} = [P^{-1}(\vec{c}_{tan} - \vec{r}_{tan})] + \vec{r}_{pix}
-
-        """
-        if plane_y is None:
-            return torch.stack(self.plane_to_pixel(*plane_x))
-        coords = torch.mm(self._pixelscale_inv, torch.stack((plane_x.reshape(-1), plane_y.reshape(-1))) - self.reference_imagexy.view(2,1)) + self.reference_imageij.view(2,1)
-        return coords[0].reshape(plane_x.shape), coords[1].reshape(plane_y.shape)
-
-    def pixel_to_plane_delta(self, pixel_delta_i, pixel_delta_j=None):
-        """Take a translation in pixel space and determine the cooresponding
-        translation in the tangent plane (arcsec). Essentially this performs
-        the pixel scale matrix multiplication without any reference
-        coordinates applied.
-
-        """
-        if pixel_delta_j is None:
-            return torch.stack(self.pixel_to_plane_delta(*pixel_delta_i))
-        coords = torch.mm(self.pixelscale, torch.stack((pixel_delta_i.reshape(-1), pixel_delta_j.reshape(-1))))
-        return coords[0].reshape(pixel_delta_i.shape), coords[1].reshape(pixel_delta_j.shape)
-
-    def plane_to_pixel_delta(self, plane_delta_x, plane_delta_y=None):
-        """Take a translation in tangent plane space (arcsec) and determine
-        the cooresponding translation in pixel space. Essentially this
-        performs the pixel scale matrix multiplication without any
-        reference coordinates applied.
-
-        """
-        if plane_delta_y is None:
-            return torch.stack(self.plane_to_pixel_delta(*plane_delta_x))
-        coords = torch.mm(self._pixelscale_inv, torch.stack((plane_delta_x.reshape(-1), plane_delta_y.reshape(-1))))
-        return coords[0].reshape(plane_delta_x.shape), coords[1].reshape(plane_delta_y.shape)
-
-    def world_to_pixel(self, world_RA, world_DEC=None):
-        """A wrapper which applies :meth:`world_to_plane` then
-        :meth:`plane_to_pixel`, see those methods for further
-        information.
-
-        """
-        if world_DEC is None:
-            return torch.stack(self.world_to_pixel(*world_RA))
-        return self.plane_to_pixel(*self.world_to_plane(world_RA, world_DEC))
-    def pixel_to_world(self, pixel_i, pixel_j=None):
-        """A wrapper which applies :meth:`pixel_to_plane` then
-        :meth:`plane_to_world`, see those methods for further
-        information.
-
-        """
-        if pixel_j is None:
-            return torch.stack(self.pixel_to_world(*pixel_i))
-        return self.plane_to_world(*self.pixel_to_plane(pixel_i, pixel_j))
-    
+            
     @property
     def zeropoint(self):
         """The photometric zeropoint of the image, used as a flux reference
@@ -493,18 +131,51 @@ class Image_Header(WPCS):
         """
         return self.window.center
 
-    def shift_origin(self, shift):
+
+    def world_to_plane(self, *args, **kwargs):
+        return self.window.world_to_plane(*args, **kwargs)
+    def plane_to_world(self, *args, **kwargs):
+        return self.window.plane_to_world(*args, **kwargs)
+    def plane_to_pixel(self, *args, **kwargs):
+        return self.window.plane_to_pixel(*args, **kwargs)
+    def pixel_to_plane(self, *args, **kwargs):
+        return self.window.pixel_to_plane(*args, **kwargs)
+    def plane_to_pixel_delta(self, *args, **kwargs):
+        return self.window.plane_to_pixel_delta(*args, **kwargs)
+    def pixel_to_plane_delta(self, *args, **kwargs):
+        return self.window.pixel_to_plane_delta(*args, **kwargs)
+    def world_to_pixel(self, *args, **kwargs):
+        return self.window.world_to_pixel(*args, **kwargs)
+    def pixel_to_world(self, *args, **kwargs):
+        return self.window.pixel_to_world(*args, **kwargs)
+    def get_coordinate_meshgrid(self):
+        return self.window.get_coordinate_meshgrid()
+    def get_coordinate_corner_meshgrid(self):
+        return self.window.get_coordinate_corner_meshgrid()
+    def get_coordinate_simps_meshgrid(self):
+        return self.window.get_coordinate_simps_meshgrid()
+
+    @property
+    def pixelscale(self):
+        return self.window.pixelscale
+    @property
+    def pixel_length(self):
+        return self.window.pixel_length
+    @property
+    def pixel_area(self):
+        return self.window.pixel_area
+    
+    def shift(self, shift):
         """Adjust the position of the image described by the header. This will
         not adjust the data represented by the header, only the
         coordinate system that maps pixel coordinates to the plane
         coordinates.
 
         """
-        self.window.shift_origin(shift)
-        self.reference_imagexy = self.reference_imagexy + shift
+        self.window.shift(shift)
 
-    def pixel_shift_origin(self, shift):
-        self.shift_origin(self.pixel_to_plane_delta(shift))
+    def pixel_shift(self, shift):
+        self.window.pixel_shift(shift)
 
     def copy(self, **kwargs):
         """Produce a copy of this image with all of the same properties. This
@@ -512,44 +183,31 @@ class Image_Header(WPCS):
         an image and then will want the original again.
 
         """
-        return super().copy(
-            data_shape=self.data_shape,
-            pixelscale=self.pixelscale,
-            zeropoint=self.zeropoint,
-            note=self.note,
-            window=self.window.copy(),
-            identity=self.identity,
-            **kwargs,
-        )
+        copy_kwargs = {
+            "zeropoint": self.zeropoint,
+            "note": self.note,
+            "window": self.window.copy(),
+            "identity": self.identity,
+        }
+        copy_kwargs.update(kwargs)
+        return self.__class__(**copy_kwargs)
 
     def get_window(self, window, **kwargs):
-        """Get a sub-region of the image as defined by a window on the sky."""
-        indices = window.get_indices(self)
-        return super().copy(
-            data_shape=(
-                indices[0].stop - indices[0].start,
-                indices[1].stop - indices[1].start,
-            ),
-            pixelscale=self.pixelscale,
-            zeropoint=self.zeropoint,
-            note=self.note,
-            window=self.window & window,#fixme, need reference_imagexy and reference_imageij defined to remain the same
-            identity=self.identity,
-            **kwargs,
-        )
+        """Get a sub-region of the image as defined by a window on the sky."""        
+        copy_kwargs = {
+            "window": self.window & window,
+        }
+        copy_kwargs.update(kwargs)
+        return self.copy(**copy_kwargs)
 
     def to(self, dtype=None, device=None):
         if dtype is None:
             dtype = AP_config.ap_dtype
         if device is None:
             device = AP_config.ap_device
-        super().to(dtype=dtype, device=device)
         self.window.to(dtype=dtype, device=device)
-        self.pixelscale.to(dtype=dtype, device=device)
         if self.zeropoint is not None:
             self.zeropoint.to(dtype=dtype, device=device)
-        self._reference_imageij = self._reference_imageij.to(dtype=dtype, device=device)
-        self._reference_imagexy = self._reference_imagexy.to(dtype=dtype, device=device)
         return self
 
     def crop(self, pixels):  # fixme data_shape?
@@ -560,189 +218,81 @@ class Image_Header(WPCS):
         all sides are specified explicitly.
 
         """
-        if len(pixels) == 1:  # same crop in all dimension
-            pix_shift = torch.as_tensor(
-                [pixels[0], pixels[0]],
-                dtype=AP_config.ap_dtype,
-                device=AP_config.ap_device,
-            )
-            self.window -= self.pixel_to_plane_delta(
-                pix_shift
-            ).abs()
-            self.reference_imageij = self.reference_imageij - pix_shift
-            self.data_shape = self.data_shape - 2 * pix_shift
-        elif len(pixels) == 2:  # different crop in each dimension
-            pix_shift = torch.as_tensor(
-                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            self.window -= self.pixel_to_plane_delta(
-                pix_shift
-            ).abs()
-            self.reference_imageij = self.reference_imageij - pix_shift
-            self.data_shape = self.data_shape - 2 * pix_shift
-        elif len(pixels) == 4:  # different crop on all sides
-            pixels = torch.as_tensor(
-                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            low = self.pixel_to_plane_delta(pixels[:2])
-            high = self.pixel_to_plane_delta(pixels[2:])
-            self.window -= torch.cat((low, high)).abs()
-            self.reference_imageij = self.reference_imageij - low
-            self.data_shape = self.data_shape - low - high
-        else:
-            raise ValueError(f"Unrecognized pixel crop format: {pixels}")
+        self.window.crop_pixel(pixels)
         return self
 
-    @torch.no_grad()
-    def get_coordinate_meshgrid(self):
-        """Returns a meshgrid with tangent plane coordinates for the center
-        of every pixel.
-
-        """
-        n_pixels = self.data_shape
-        xsteps = torch.arange(
-            n_pixels[1], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-        ysteps = torch.arange(
-            n_pixels[0], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-        meshx, meshy = torch.meshgrid(
-            xsteps,
-            ysteps,
-            indexing="xy",
-        )
-        Coords = self.pixel_to_plane(meshx, meshy)
-        return torch.stack(Coords)
-
-    @torch.no_grad()
-    def get_coordinate_corner_meshgrid(self):
-        """Returns a meshgrid with tangent plane coordinates for the corners
-        of every pixel.
-
-        """
-        n_pixels = self.data_shape
-        xsteps = (
-            torch.arange(
-                n_pixels[1] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            - 0.5
-        )
-        ysteps = (
-            torch.arange(
-                n_pixels[0] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            - 0.5
-        )
-        meshx, meshy = torch.meshgrid(
-            xsteps,
-            ysteps,
-            indexing="xy",
-        )
-        Coords = self.pixel_to_plane(meshx, meshy)
-        return torch.stack(Coords)
-
-    @torch.no_grad()
-    def get_coordinate_simps_meshgrid(self):
-        """Returns a meshgrid with tangent plane coordinates for performing
-        simpsons method pixel integration (all corners, centers, and
-        middle of each edge). This is approximately 4 times more
-        points than the standard :meth:`get_coordinate_meshgrid`.
-
-        """
-        n_pixels = self.data_shape
-        xsteps = (
-            0.5
-            * torch.arange(
-                2 * (n_pixels[1]) + 1,
-                dtype=AP_config.ap_dtype,
-                device=AP_config.ap_device,
-            )
-            - 0.5
-        )
-        ysteps = (
-            0.5
-            * torch.arange(
-                2 * (n_pixels[0]) + 1,
-                dtype=AP_config.ap_dtype,
-                device=AP_config.ap_device,
-            )
-            - 0.5
-        )
-        meshx, meshy = torch.meshgrid(
-            xsteps,
-            ysteps,
-            indexing="xy",
-        )
-        Coords = self.pixel_to_plane(meshx, meshy)
-        return torch.stack(Coords)
-
-    def super_resolve(self, scale: int, **kwargs):
-        """Increase the resolution of the referenced image by the provided
-        scale (int).
-
-        """
-        assert isinstance(scale, int) or scale.dtype is torch.int32
+    def rescale(self, scale: int, **kwargs):
         if scale == 1:
             return self
-
-        return super().copy(
-            data_shape=self.data_shape,
-            pixelscale=self.pixelscale / scale,
-            zeropoint=self.zeropoint,
-            note=self.note,
-            window=self.window.copy(),
-            identity=self.identity,
+        
+        return self.copy(
+            window = self.window.rescale(scale),
             **kwargs,
         )
+    
+    # def super_resolve(self, scale: int, **kwargs):
+    #     """Increase the resolution of the referenced image by the provided
+    #     scale (int).
 
-    def reduce(self, scale: int, **kwargs):
-        """This operation will downsample an image by the factor given. If
-        scale = 2 then 2x2 blocks of pixels will be summed together to
-        form individual larger pixels. A new image object will be
-        returned with the appropriate pixelscale and data tensor. Note
-        that the window does not change in this operation since the
-        pixels are condensed, but the pixel size is increased
-        correspondingly.
+    #     """
+    #     assert isinstance(scale, int) or scale.dtype is torch.int32
+    #     if scale == 1:
+    #         return self
 
-        Args:
-            scale: factor by which to condense the image pixels. Each scale X scale region will be summed [int]
+    #     return super().copy(
+    #         data_shape=self.data_shape,
+    #         pixelscale=self.pixelscale / scale,
+    #         zeropoint=self.zeropoint,
+    #         note=self.note,
+    #         window=self.window.copy(),
+    #         identity=self.identity,
+    #         **kwargs,
+    #     )
 
-        """
-        assert isinstance(scale, int) or scale.dtype is torch.int32
-        if scale == 1:
-            return self
+    # def reduce(self, scale: int, **kwargs):
+    #     """This operation will downsample an image by the factor given. If
+    #     scale = 2 then 2x2 blocks of pixels will be summed together to
+    #     form individual larger pixels. A new image object will be
+    #     returned with the appropriate pixelscale and data tensor. Note
+    #     that the window does not change in this operation since the
+    #     pixels are condensed, but the pixel size is increased
+    #     correspondingly.
 
-        return super().copy(
-            data_shape=self.data_shape,
-            pixelscale=self.pixelscale * scale,
-            zeropoint=self.zeropoint,
-            note=self.note,
-            window=self.window.copy(),
-            identity=self.identity,
-            **kwargs,
-        )
+    #     Args:
+    #         scale: factor by which to condense the image pixels. Each scale X scale region will be summed [int]
 
-    def expand(self, padding: Tuple[float]) -> None:
-        """
-        Args:
-          padding tuple[float]: length 4 tuple with amounts to pad each dimension in physical units
-        """
-        # fixme
-        padding = np.array(padding)
-        assert np.all(padding >= 0), "negative padding not allowed in expand method"
-        pad_boundaries = tuple(np.int64(np.round(np.array(padding) / self.pixelscale)))
-        self.window += tuple(padding)
+    #     """
+    #     assert isinstance(scale, int) or scale.dtype is torch.int32
+    #     if scale == 1:
+    #         return self
 
+    #     return super().copy(
+    #         data_shape=self.data_shape,
+    #         pixelscale=self.pixelscale * scale,
+    #         zeropoint=self.zeropoint,
+    #         note=self.note,
+    #         window=self.window.copy(),
+    #         identity=self.identity,
+    #         **kwargs,
+    #     )
+
+    # def expand(self, padding: Tuple[float]) -> None:
+    #     """
+    #     Args:
+    #       padding tuple[float]: length 4 tuple with amounts to pad each dimension in physical units
+    #     """
+    #     # fixme
+    #     padding = np.array(padding)
+    #     assert np.all(padding >= 0), "negative padding not allowed in expand method"
+    #     pad_boundaries = tuple(np.int64(np.round(np.array(padding) / self.pixelscale)))
+    #     self.window += tuple(padding)
+    
     def get_state(self):
         """Returns a dictionary with necessary information to recreate the
         Image_Header object.
 
         """
-        state = super().get_state()
-        state["data_shape"] = self.data_shape.detach().cpu().tolist()
-        state["pixelscale"] = self.pixelscale.detach().cpu().tolist()
-        state["reference_imageij"] = self.reference_imageij.detach().cpu().tolist()
-        state["reference_imagexy"] = self.reference_imagexy.detach().cpu().tolist()
+        state = {}
         if self.zeropoint is not None:
             state["zeropoint"] = self.zeropoint.item()
         state["window"] = self.window.get_state()
@@ -754,12 +304,9 @@ class Image_Header(WPCS):
         """
         Constructs a fits header object which has the necessary information to recreate the Image_Header object.
         """
-        img_header = fits.Header(super().get_fits_state())
+        img_header = fits.Header()
         img_header["IMAGE"] = "PRIMARY"
-        img_header["PXLSCALE"] = str(self.pixelscale.detach().cpu().tolist())
         img_header["WINDOW"] = str(self.window.get_state())
-        img_header["REFIMIJ"] = str(self.reference_imageij.detach().cpu().tolist())
-        img_header["REFIMXY"] = str(self.reference_imagexy.detach().cpu().tolist())
         if not self.zeropoint is None:
             img_header["ZEROPNT"] = str(self.zeropoint.detach().cpu().item())
         if not self.note is None:
@@ -770,11 +317,7 @@ class Image_Header(WPCS):
         """
         Updates the state of the Image_Header using information saved in a fits header.
         """
-        super().set_fits_state(state)
-        self.pixelscale = eval(state["PXLSCALE"])
         self.zeropoint = eval(state.get("ZEROPNT", "None"))
-        self.reference_imageij = eval(state["REFIMIJ"])
-        self.reference_imagexy = eval(state["REFIMXY"])
         self.note = state.get("NOTE",None)
         self.window = Window(state=eval(state["WINDOW"]))
         
@@ -801,7 +344,8 @@ class Image_Header(WPCS):
 
     def __str__(self):
         state = self.get_state()
-        keys = ["data_shape", "pixelscale", "reference_imageij", "reference_imagexy"]
+        state.update(self.window.get_state())
+        keys = ["pixel_shape", "pixelscale", "reference_imageij", "reference_imagexy"]
         if "zeropoint" in state:
             keys.append("zeropoint")
         if "note" in state:
@@ -810,4 +354,5 @@ class Image_Header(WPCS):
 
     def __repr__(self):
         state = self.get_state()
+        state.update(self.window.get_state())
         return "\n".join(f"{key}: {state[key]}" for key in sorted(state.keys()))

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn.functional import pad
 import numpy as np
 from astropy.io import fits
-from astropy.wcs import WCS
+from astropy.wcs import WCS as AstropyWCS
 
 from .window_object import Window, Window_List
 from .image_header import Image_Header
@@ -35,7 +35,7 @@ class Image(object):
         *,
         data: Optional[Union[torch.Tensor]] = None,
         header: Optional[Image_Header] = None,
-        wcs: Optional["astropy.wcs.wcs.WCS"] = None,
+        wcs: Optional[AstropyWCS] = None,
         pixelscale: Optional[Union[float, torch.Tensor]] = None,
         window: Optional[Window] = None,
         filename: Optional[str] = None,
@@ -115,17 +115,28 @@ class Image(object):
     def pixel_length(self):
         return self.header.pixel_length
 
-    def pixel_to_plane(self, *args, **kwargs):
-        return self.header.pixel_to_plane(*args, **kwargs)
-
+    def world_to_plane(self, *args, **kwargs):
+        return self.window.world_to_plane(*args, **kwargs)
+    def plane_to_world(self, *args, **kwargs):
+        return self.window.plane_to_world(*args, **kwargs)
     def plane_to_pixel(self, *args, **kwargs):
-        return self.header.plane_to_pixel(*args, **kwargs)
-
-    def pixel_to_plane_delta(self, *args, **kwargs):
-        return self.header.pixel_to_plane_delta(*args, **kwargs)
-
+        return self.window.plane_to_pixel(*args, **kwargs)
+    def pixel_to_plane(self, *args, **kwargs):
+        return self.window.pixel_to_plane(*args, **kwargs)
     def plane_to_pixel_delta(self, *args, **kwargs):
-        return self.header.plane_to_pixel_delta(*args, **kwargs)
+        return self.window.plane_to_pixel_delta(*args, **kwargs)
+    def pixel_to_plane_delta(self, *args, **kwargs):
+        return self.window.pixel_to_plane_delta(*args, **kwargs)
+    def world_to_pixel(self, *args, **kwargs):
+        return self.window.world_to_pixel(*args, **kwargs)
+    def pixel_to_world(self, *args, **kwargs):
+        return self.window.pixel_to_world(*args, **kwargs)
+    def get_coordinate_meshgrid(self):
+        return self.window.get_coordinate_meshgrid()
+    def get_coordinate_corner_meshgrid(self):
+        return self.window.get_coordinate_corner_meshgrid()
+    def get_coordinate_simps_meshgrid(self):
+        return self.window.get_coordinate_simps_meshgrid()
 
     @property
     def origin(self) -> torch.Tensor:
@@ -364,7 +375,7 @@ class Image(object):
             new_img.data -= other.data[self.window.get_other_indices(other)]
             return new_img
         else:
-            new_img = self[other.window.get_other_indices(self)].copy()
+            new_img = self.copy()
             new_img.data -= other
             return new_img
 
@@ -374,27 +385,7 @@ class Image(object):
             new_img.data += other.data[self.window.get_other_indices(other)]
             return new_img
         else:
-            new_img = self[other.window.get_other_indices(self)].copy()
-            new_img.data += other
-            return new_img
-
-    def __sub__(self, other):
-        if isinstance(other, Image):
-            new_img = self[other.window].copy()
-            new_img.data -= other.data[self.window.get_other_indices(other)]
-            return new_img
-        else:
-            new_img = self[other.window.get_other_indices(self)].copy()
-            new_img.data -= other
-            return new_img
-
-    def __add__(self, other):
-        if isinstance(other, Image):
-            new_img = self[other.window].copy()
-            new_img.data += other.data[self.window.get_other_indices(other)]
-            return new_img
-        else:
-            new_img = self[other.window.get_other_indices(self)].copy()
+            new_img = self.copy()
             new_img.data += other
             return new_img
 

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -238,7 +238,7 @@ class Image(object):
     def get_window(self, window, **kwargs):
         """Get a sub-region of the image as defined by a window on the sky."""
         return self.__class__(
-            data=self.data[window.get_indices(self)],
+            data=self.data[self.window.get_self_indices(window)],
             header=self.header.get_window(window, **kwargs),
             **kwargs,
         )
@@ -358,47 +358,47 @@ class Image(object):
     def __sub__(self, other):
         if isinstance(other, Image):
             new_img = self[other.window].copy()
-            new_img.data -= other.data[self.window.get_indices(other)]
+            new_img.data -= other.data[self.window.get_other_indices(other)]
             return new_img
         else:
-            new_img = self[other.window.get_indices(self)].copy()
+            new_img = self[other.window.get_other_indices(self)].copy()
             new_img.data -= other
             return new_img
 
     def __add__(self, other):
         if isinstance(other, Image):
             new_img = self[other.window].copy()
-            new_img.data += other.data[self.window.get_indices(other)]
+            new_img.data += other.data[self.window.get_other_indices(other)]
             return new_img
         else:
-            new_img = self[other.window.get_indices(self)].copy()
+            new_img = self[other.window.get_other_indices(self)].copy()
             new_img.data += other
             return new_img
 
     def __sub__(self, other):
         if isinstance(other, Image):
             new_img = self[other.window].copy()
-            new_img.data -= other.data[self.window.get_indices(other)]
+            new_img.data -= other.data[self.window.get_other_indices(other)]
             return new_img
         else:
-            new_img = self[other.window.get_indices(self)].copy()
+            new_img = self[other.window.get_other_indices(self)].copy()
             new_img.data -= other
             return new_img
 
     def __add__(self, other):
         if isinstance(other, Image):
             new_img = self[other.window].copy()
-            new_img.data += other.data[self.window.get_indices(other)]
+            new_img.data += other.data[self.window.get_other_indices(other)]
             return new_img
         else:
-            new_img = self[other.window.get_indices(self)].copy()
+            new_img = self[other.window.get_other_indices(self)].copy()
             new_img.data += other
             return new_img
 
     def __iadd__(self, other):
         if isinstance(other, Image):
-            self.data[other.window.get_indices(self)] += other.data[
-                self.window.get_indices(other)
+            self.data[other.window.get_other_indices(self)] += other.data[
+                self.window.get_other_indices(other)
             ]
         else:
             self.data += other
@@ -406,8 +406,8 @@ class Image(object):
 
     def __isub__(self, other):
         if isinstance(other, Image):
-            self.data[other.window.get_indices(self)] -= other.data[
-                self.window.get_indices(other)
+            self.data[other.window.get_other_indices(self)] -= other.data[
+                self.window.get_other_indices(other)
             ]
         else:
             self.data -= other

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -436,20 +436,20 @@ class Image_List(Image):
         self.check_wcs()
         
     def check_wcs(self):
-        """Ensure the WCS system being used by all the windows in this list
+        """Ensure the WCS systems being used by all the windows in this list
         are consistent with each other. They should all project world
         coordinates onto the same tangent plane.
 
         """
         ref = torch.stack(tuple(I.window.reference_radec for I in self.image_list))
         if not torch.allclose(ref, ref[0]):
-            AP_config.ap_logger.error("Reference coordinate (RA DEC) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference coordinate (RA DEC) mismatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
         ref = torch.stack(tuple(I.window.reference_planexy for I in self.image_list))
         if not torch.allclose(ref, ref[0]):
-            AP_config.ap_logger.error("Reference coordinate (tangent plane) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference coordinate (tangent plane) mismatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
         if len(set(I.window.projection for I in self.image_list)) > 1:
-            AP_config.ap_logger.error("Projection missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Projection mismatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
     @property
     def window(self):

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -432,6 +432,20 @@ class Image(object):
 class Image_List(Image):
     def __init__(self, image_list):
         self.image_list = list(image_list)
+        self.check_wcs()
+        
+    def check_wcs(self):
+        """Ensure the WCS system being used by all the windows in this list
+        are consistent with each other. They should all project world
+        coordinates onto the same tangent plane.
+
+        """
+        ref = torch.stack(tuple(I.header.reference_radec for I in self.image_list))
+        if not torch.allclose(ref, ref[0]):
+            AP_config.error("Reference coordiante missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+
+        if len(set(I.header.projection for I in self.image_list)) > 1:
+            AP_config.error("Projection missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
     @property
     def window(self):

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -317,7 +317,7 @@ class Image(object):
             data=self.data[: MS * scale, : NS * scale]
             .reshape(MS, scale, NS, scale)
             .sum(axis=(1, 3)),
-            header=self.header.reduce(scale, **kwargs),
+            header=self.header.rescale(1/scale, **kwargs),
             **kwargs,
         )
 
@@ -438,11 +438,14 @@ class Image_List(Image):
         coordinates onto the same tangent plane.
 
         """
-        ref = torch.stack(tuple(I.header.reference_radec for I in self.image_list))
+        ref = torch.stack(tuple(I.window.reference_radec for I in self.image_list))
         if not torch.allclose(ref, ref[0]):
-            AP_config.error("Reference coordiante missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.error("Reference coordiante (RA DEC) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+        ref = torch.stack(tuple(I.window.reference_planexy for I in self.image_list))
+        if not torch.allclose(ref, ref[0]):
+            AP_config.error("Reference coordiante (tangent plane) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
-        if len(set(I.header.projection for I in self.image_list)) > 1:
+        if len(set(I.window.projection for I in self.image_list)) > 1:
             AP_config.error("Projection missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
     @property

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -32,6 +32,7 @@ class Image(object):
 
     def __init__(
         self,
+        *,
         data: Optional[Union[torch.Tensor]] = None,
         header: Optional[Image_Header] = None,
         wcs: Optional["astropy.wcs.wcs.WCS"] = None,
@@ -426,7 +427,6 @@ class Image(object):
 
     def __repr__(self):
         return f"image pixelscale: {self.pixelscale.detach().cpu().numpy()} origin: {self.origin.detach().cpu().numpy()} shape: {self.shape.detach().cpu().numpy()} center: {self.center.detach().cpu().numpy()}\ndata: {self.data.detach().cpu().numpy()}"
-        
 
 
 class Image_List(Image):
@@ -580,7 +580,7 @@ class Image_List(Image):
     def __repr__(self):
         return f"image list of:\n" + "\n".join(
             image.__repr__() for image in self.image_list
-        ) 
+        )
 
     def __iter__(self):
         return (img for img in self.image_list)

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -443,13 +443,13 @@ class Image_List(Image):
         """
         ref = torch.stack(tuple(I.window.reference_radec for I in self.image_list))
         if not torch.allclose(ref, ref[0]):
-            AP_config.error("Reference coordiante (RA DEC) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference coordinate (RA DEC) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
         ref = torch.stack(tuple(I.window.reference_planexy for I in self.image_list))
         if not torch.allclose(ref, ref[0]):
-            AP_config.error("Reference coordiante (tangent plane) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference coordinate (tangent plane) missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
         if len(set(I.window.projection for I in self.image_list)) > 1:
-            AP_config.error("Projection missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Projection missmatch! All images in Image_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
     @property
     def window(self):

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -111,19 +111,19 @@ class Image(object):
     def pixel_length(self):
         return self.header.pixel_length
 
-    def pixel_to_world(self, pixel_coordinate, internal_transpose=False):
-        return self.header.pixel_to_world(
+    def pixel_to_plane(self, pixel_coordinate, internal_transpose=False):
+        return self.header.pixel_to_plane(
             pixel_coordinate, internal_transpose=internal_transpose
         )
 
-    def world_to_pixel(self, world_coordinate, unsqueeze_origin=False):
-        return self.header.world_to_pixel(world_coordinate, unsqueeze_origin)
+    def plane_to_pixel(self, plane_coordinate, unsqueeze_origin=False):
+        return self.header.plane_to_pixel(plane_coordinate, unsqueeze_origin)
 
-    def pixel_to_world_delta(self, pixel_coordinate):
-        return self.header.pixel_to_world_delta(pixel_coordinate)
+    def pixel_to_plane_delta(self, pixel_coordinate):
+        return self.header.pixel_to_plane_delta(pixel_coordinate)
 
-    def world_to_pixel_delta(self, world_coordinate):
-        return self.header.world_to_pixel_delta(world_coordinate)
+    def plane_to_pixel_delta(self, plane_coordinate):
+        return self.header.plane_to_pixel_delta(plane_coordinate)
 
     @property
     def origin(self) -> torch.Tensor:
@@ -422,7 +422,11 @@ class Image(object):
         raise ValueError("Unrecognized Image getitem request!")
 
     def __str__(self):
-        return f"image pixelscale: {self.pixelscale} origin: {self.origin}\ndata: {self.data}"
+        return f"image pixelscale: {self.pixelscale.detach().cpu().numpy()} origin: {self.origin.detach().cpu().numpy()} shape: {self.shape.detach().cpu().numpy()}"
+
+    def __repr__(self):
+        return f"image pixelscale: {self.pixelscale.detach().cpu().numpy()} origin: {self.origin.detach().cpu().numpy()} shape: {self.shape.detach().cpu().numpy()} center: {self.center.detach().cpu().numpy()}\ndata: {self.data.detach().cpu().numpy()}"
+        
 
 
 class Image_List(Image):
@@ -572,6 +576,11 @@ class Image_List(Image):
         return f"image list of:\n" + "\n".join(
             image.__str__() for image in self.image_list
         )
+
+    def __repr__(self):
+        return f"image list of:\n" + "\n".join(
+            image.__repr__() for image in self.image_list
+        ) 
 
     def __iter__(self):
         return (img for img in self.image_list)

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -112,17 +112,17 @@ class Image(object):
     def pixel_length(self):
         return self.header.pixel_length
 
-    def pixel_to_plane(self, pixel_coordinate):
-        return self.header.pixel_to_plane(pixel_coordinate)
+    def pixel_to_plane(self, *args, **kwargs):
+        return self.header.pixel_to_plane(*args, **kwargs)
 
-    def plane_to_pixel(self, plane_coordinate):
-        return self.header.plane_to_pixel(plane_coordinate)
+    def plane_to_pixel(self, *args, **kwargs):
+        return self.header.plane_to_pixel(*args, **kwargs)
 
-    def pixel_to_plane_delta(self, pixel_coordinate):
-        return self.header.pixel_to_plane_delta(pixel_coordinate)
+    def pixel_to_plane_delta(self, *args, **kwargs):
+        return self.header.pixel_to_plane_delta(*args, **kwargs)
 
-    def plane_to_pixel_delta(self, plane_coordinate):
-        return self.header.plane_to_pixel_delta(plane_coordinate)
+    def plane_to_pixel_delta(self, *args, **kwargs):
+        return self.header.plane_to_pixel_delta(*args, **kwargs)
 
     @property
     def origin(self) -> torch.Tensor:

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -112,13 +112,11 @@ class Image(object):
     def pixel_length(self):
         return self.header.pixel_length
 
-    def pixel_to_plane(self, pixel_coordinate, internal_transpose=False):
-        return self.header.pixel_to_plane(
-            pixel_coordinate, internal_transpose=internal_transpose
-        )
+    def pixel_to_plane(self, pixel_coordinate):
+        return self.header.pixel_to_plane(pixel_coordinate)
 
-    def plane_to_pixel(self, plane_coordinate, unsqueeze_origin=False):
-        return self.header.plane_to_pixel(plane_coordinate, unsqueeze_origin)
+    def plane_to_pixel(self, plane_coordinate):
+        return self.header.plane_to_pixel(plane_coordinate)
 
     def pixel_to_plane_delta(self, pixel_coordinate):
         return self.header.pixel_to_plane_delta(pixel_coordinate)

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -100,6 +100,9 @@ class Image(object):
         self.data = data
         self.to()
 
+        # # Check that image data and header are in agreement (this requires talk back from GPU to CPU so is only used for testing)
+        # assert np.all(np.flip(np.array(self.data.shape)[:2]) == self.window.pixel_shape.numpy()), f"data shape {np.flip(np.array(self.data.shape)[:2])}, window shape {self.window.pixel_shape.numpy()}"
+
     @property
     def north(self):
         return self.header.north
@@ -317,7 +320,7 @@ class Image(object):
             data=self.data[: MS * scale, : NS * scale]
             .reshape(MS, scale, NS, scale)
             .sum(axis=(1, 3)),
-            header=self.header.rescale(1/scale, **kwargs),
+            header=self.header.rescale_pixel(scale, **kwargs),
             **kwargs,
         )
 

--- a/astrophot/image/jacobian_image.py
+++ b/astrophot/image/jacobian_image.py
@@ -65,8 +65,8 @@ class Jacobian_Image(Image):
 
         full_window = self.window | other.window
 
-        self_indices = other.window.get_indices(self)
-        other_indices = self.window.get_indices(other)
+        self_indices = other.window.get_other_indices(self)
+        other_indices = self.window.get_other_indices(other)
         for i, other_identity in enumerate(other.parameters):
             if other_identity in self.parameters:
                 other_loc = self.parameters.index(other_identity)

--- a/astrophot/image/jacobian_image.py
+++ b/astrophot/image/jacobian_image.py
@@ -64,8 +64,6 @@ class Jacobian_Image(Image):
             return other
 
         full_window = self.window | other.window
-        if full_window > self.window:
-            warnings.warn("Jacobian image addition without full coverage")
 
         self_indices = other.window.get_indices(self)
         other_indices = self.window.get_indices(other)

--- a/astrophot/image/model_image.py
+++ b/astrophot/image/model_image.py
@@ -23,7 +23,7 @@ class Model_Image(Image):
         assert not (data is None and window is None)
         if data is None:
             data = torch.zeros(
-                tuple(window.get_shape_flip(pixelscale)),
+                torch.flip(window.pixel_shape,(0,)).detach().cpu().tolist(),
                 dtype=AP_config.ap_dtype,
                 device=AP_config.ap_device,
             )
@@ -35,7 +35,7 @@ class Model_Image(Image):
         self.data = torch.zeros_like(self.data)
 
     def shift_origin(self, shift, is_prepadded=True):
-        self.window.shift_origin(shift)
+        self.window.shift(shift)
         pix_shift = self.plane_to_pixel_delta(shift)
         if torch.any(torch.abs(pix_shift) > 1):
             raise NotImplementedError(

--- a/astrophot/image/model_image.py
+++ b/astrophot/image/model_image.py
@@ -36,7 +36,7 @@ class Model_Image(Image):
 
     def shift_origin(self, shift, is_prepadded=True):
         self.window.shift_origin(shift)
-        pix_shift = self.world_to_pixel_delta(shift)
+        pix_shift = self.plane_to_pixel_delta(shift)
         if torch.any(torch.abs(pix_shift) > 1):
             raise NotImplementedError(
                 "Shifts larger than 1 pixel are currently not handled"

--- a/astrophot/image/model_image.py
+++ b/astrophot/image/model_image.py
@@ -63,8 +63,8 @@ class Model_Image(Image):
         if isinstance(other, Image):
             if self.window.overlap_frac(other.window) == 0.0:  # fixme control flow
                 return
-            other_indices = self.window.get_indices(other)
-            self_indices = other.window.get_indices(self)
+            other_indices = self.window.get_other_indices(other)
+            self_indices = other.window.get_other_indices(self)
             if (
                 self.data[self_indices].nelement() == 0
                 or other.data[other_indices].nelement() == 0
@@ -72,7 +72,7 @@ class Model_Image(Image):
                 return
             self.data[self_indices] = other.data[other_indices]
         elif isinstance(other, Window):
-            self.data[other.get_indices(self)] = data
+            self.data[self.get_self_indices(other)] = data
         else:
             self.data = other
 

--- a/astrophot/image/model_image.py
+++ b/astrophot/image/model_image.py
@@ -72,7 +72,7 @@ class Model_Image(Image):
                 return
             self.data[self_indices] = other.data[other_indices]
         elif isinstance(other, Window):
-            self.data[self.get_self_indices(other)] = data
+            self.data[self.window.get_self_indices(other)] = data
         else:
             self.data = other
 

--- a/astrophot/image/psf_image.py
+++ b/astrophot/image/psf_image.py
@@ -84,8 +84,8 @@ class PSF_Image(Image):
             torch.Tensor: The border size of the PSF image in the units of pixelscale.
 
         """
-        return self.window.world_to_cartesian(
-            self.pixel_to_world_delta(self.psf_border_int.to(dtype=AP_config.ap_dtype))
+        return self.window.plane_to_cartesian(
+            self.pixel_to_plane_delta(self.psf_border_int.to(dtype=AP_config.ap_dtype))
         )
 
     def _save_image_list(self, image_list, psf_header):

--- a/astrophot/image/psf_image.py
+++ b/astrophot/image/psf_image.py
@@ -45,6 +45,10 @@ class PSF_Image(Image):
             kwargs.get("psf_upscale", 1), dtype=torch.int32, device=AP_config.ap_device
         )
         super().__init__(*args, **kwargs)
+        self.reference_radec = (0,0)
+        self.reference_planexy = (0,0)
+        self.reference_imageij = np.flip(np.array(self.data.shape, dtype = float) - 1.) / 2
+        self.reference_imagexy = (0,0)
         assert torch.all(
             (torch.tensor(self.data.shape) % 2) == 1
         ), "psf must have odd shape"

--- a/astrophot/image/psf_image.py
+++ b/astrophot/image/psf_image.py
@@ -74,19 +74,20 @@ class PSF_Image(Image):
             / 2
         ).int()
 
-    @property
-    def psf_border(self):
-        """Calculates and returns the border size of the PSF image in the
-        units of pixelscale. This is the border used for padding
-        before convolution.
+    # @property
+    # def psf_border(self):
+    #     """Calculates and returns the border size of the PSF image in the
+    #     units of arcsec. This is the border used for padding
+    #     before convolution.
 
-        Returns:
-            torch.Tensor: The border size of the PSF image in the units of pixelscale.
+    #     Returns:
+    #         torch.Tensor: The border size of the PSF image in arcsec.
 
-        """
-        return self.window.plane_to_cartesian(
-            self.pixel_to_plane_delta(self.psf_border_int.to(dtype=AP_config.ap_dtype))
-        )
+    #     """
+        
+    #     return self.window.plane_to_cartesian(
+    #         self.pixel_to_plane_delta(self.psf_border_int.to(dtype=AP_config.ap_dtype))
+    #     )
 
     def _save_image_list(self, image_list, psf_header):
         """Saves the image list to the PSF HDU header.

--- a/astrophot/image/psf_image.py
+++ b/astrophot/image/psf_image.py
@@ -74,21 +74,6 @@ class PSF_Image(Image):
             / 2
         ).int()
 
-    # @property
-    # def psf_border(self):
-    #     """Calculates and returns the border size of the PSF image in the
-    #     units of arcsec. This is the border used for padding
-    #     before convolution.
-
-    #     Returns:
-    #         torch.Tensor: The border size of the PSF image in arcsec.
-
-    #     """
-        
-    #     return self.window.plane_to_cartesian(
-    #         self.pixel_to_plane_delta(self.psf_border_int.to(dtype=AP_config.ap_dtype))
-    #     )
-
     def _save_image_list(self, image_list, psf_header):
         """Saves the image list to the PSF HDU header.
 

--- a/astrophot/image/target_image.py
+++ b/astrophot/image/target_image.py
@@ -381,7 +381,7 @@ class Target_Image(Image):
 
     def get_window(self, window, **kwargs):
         """Get a sub-region of the image as defined by a window on the sky."""
-        indices = window.get_indices(self)
+        indices = self.window.get_self_indices(window)
         return super().get_window(
             window=window,
             weight=self._weight[indices] if self.has_weight else None,

--- a/astrophot/image/target_image.py
+++ b/astrophot/image/target_image.py
@@ -24,7 +24,7 @@ class Target_Image(Image):
     be fit. There is minimial functionality in the `Target_Image`
     object itself, it is mostly defined in terms of how other objects
     interact with it.
-    
+
     Basic usage:
 
     .. code-block:: python
@@ -109,7 +109,7 @@ class Target_Image(Image):
         if self.has_variance:
             return torch.sqrt(self.variance)
         return torch.ones_like(self.data)
-            
+
     @property
     def variance(self):
         """Stores the variance of the image pixels. This represents the
@@ -121,7 +121,7 @@ class Target_Image(Image):
         The variance is not stored directly, instead it is
         computed as :math:`\\frac{1}{W}` where :math:`W` is the
         weights.
-        
+
         """
         if self.has_variance:
             return torch.where(self._weight == 0, torch.inf, 1 / self._weight)
@@ -178,11 +178,11 @@ class Target_Image(Image):
         if self.has_weight:
             return self._weight
         return torch.ones_like(self.data)
-    
+
     @weight.setter
     def weight(self, weight):
         self.set_weight(weight)
-        
+
     @property
     def has_weight(self):
         """Returns True when the image object has stored weight values. If
@@ -195,7 +195,7 @@ class Target_Image(Image):
         except AttributeError:
             self._weight = None
             return False
-        
+
     @property
     def mask(self):
         """The mask stores a tensor of boolean values which indicate any
@@ -281,9 +281,7 @@ class Target_Image(Image):
         if weight is None:
             self._weight = None
             return
-        assert (
-            weight.shape == self.data.shape
-        ), "weight must have same shape as data"
+        assert weight.shape == self.data.shape, "weight must have same shape as data"
         self._weight = (
             weight.to(dtype=AP_config.ap_dtype, device=AP_config.ap_device)
             if isinstance(weight, torch.Tensor)
@@ -310,7 +308,7 @@ class Target_Image(Image):
             return
 
         self._psf = PSF_Image(
-            psf,
+            data=psf,
             psf_upscale=psf_upscale,
             pixelscale=self.pixelscale / psf_upscale,
             identity=self.identity,
@@ -496,7 +494,7 @@ class Target_Image(Image):
             if "IMAGE" in hdu.header and hdu.header["IMAGE"] == "PSF":
                 self.set_psf(
                     PSF_Image(
-                        np.array(hdu.data, dtype=np.float64),
+                        data=np.array(hdu.data, dtype=np.float64),
                         psf_upscale=hdu.header["UPSCALE"],
                         pixelscale=self.pixelscale / hdu.header["UPSCALE"],
                     )

--- a/astrophot/image/wcs.py
+++ b/astrophot/image/wcs.py
@@ -2,6 +2,8 @@ from abc import ABC
 import torch
 import numpy as np
 
+from .. import AP_config
+
 __all__ = ("WCS",)
 
 deg_to_rad = np.pi / 180
@@ -9,14 +11,15 @@ rad_to_deg = 180 / np.pi
 rad_to_arcsec = rad_to_deg * 3600
 arcsec_to_rad = deg_to_rad / 3600
 
-class WCS():
+
+class WCS:
     """Class to handle WCS interpretation in AstroPhot.
 
     AstroPhot performs it's operations on a tangent plane to the
     sphere, this class handles projections between the sphere and the
     tangent plane. It holds class variables for the reference (RA,DEC)
     where the tangent plane contacts the sphere, and the type of
-    projection being performed. Note that (RA,DEC) coordinates should always be in degrees while the tangent plane is in arcsec coordinates. 
+    projection being performed. Note that (RA,DEC) coordinates should always be in degrees while the tangent plane is in arcsec coordinates.
 
     Attributes:
       reference_radec: The reference (RA,DEC) coordinates in degrees where the tangent plane contacts the sphere.
@@ -26,68 +29,101 @@ class WCS():
 
     _reference_radec = None
     _projection = None
-    
+
     def __init__(self, *args, **kwargs):
-            
+
         if self.projection is None:
             self.projection = "gnomonic"
         if self.reference_radec is None:
-            self.reference_radec = kwargs.get("reference_radec", (0,0))
+            self.reference_radec = kwargs.get("reference_radec", (0, 0))
 
     @classmethod
     def world_to_plane(cls, world_RA, world_DEC):
         if cls._projection == "gnomonic":
             return cls.world_to_plane_gnomonic(
-                torch.as_tensor(world_RA, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-                torch.as_tensor(world_DEC, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-            ) 
+                torch.as_tensor(
+                    world_RA, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+                torch.as_tensor(
+                    world_DEC, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+            )
         if cls._projection == "orthographic":
             return cls.world_to_plane_orthographic(
-                torch.as_tensor(world_RA, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-                torch.as_tensor(world_DEC, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-            ) 
+                torch.as_tensor(
+                    world_RA, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+                torch.as_tensor(
+                    world_DEC, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+            )
         if cls._projection == "steriographic":
             return cls.world_to_plane_steriographic(
-                torch.as_tensor(world_RA, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-                torch.as_tensor(world_DEC, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-            ) 
-        raise ValueError(f"Unrecognized projection: {cls._projection}. Should be one of: gnomonic, orthographic, steriographic")
+                torch.as_tensor(
+                    world_RA, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+                torch.as_tensor(
+                    world_DEC, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+            )
+        raise ValueError(
+            f"Unrecognized projection: {cls._projection}. Should be one of: gnomonic, orthographic, steriographic"
+        )
+
     @classmethod
     def plane_to_world(cls, plane_x, plane_y):
         if cls._projection == "gnomonic":
             return cls.plane_to_world_gnomonic(
-                torch.as_tensor(plane_x, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-                torch.as_tensor(plane_y, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-            ) 
+                torch.as_tensor(
+                    plane_x, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+                torch.as_tensor(
+                    plane_y, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+            )
         if cls._projection == "orthographic":
             return cls.plane_to_world_orthographic(
-                torch.as_tensor(plane_x, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-                torch.as_tensor(plane_y, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-            ) 
+                torch.as_tensor(
+                    plane_x, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+                torch.as_tensor(
+                    plane_y, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+            )
         if cls._projection == "steriographic":
             return cls.plane_to_world_steriographic(
-                torch.as_tensor(plane_x, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-                torch.as_tensor(plane_y, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
-            ) 
-        raise ValueError(f"Unrecognized projection: {cls._projection}. Should be one of: gnomonic, orthographic, steriographic")
-        
+                torch.as_tensor(
+                    plane_x, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+                torch.as_tensor(
+                    plane_y, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+                ),
+            )
+        raise ValueError(
+            f"Unrecognized projection: {cls._projection}. Should be one of: gnomonic, orthographic, steriographic"
+        )
+
     @property
     def projection(self):
         return self._projection
+
     @projection.setter
     def projection(self, proj):
-        assert proj in ["gnomonic", "orthographic", "steriographic"], f"Unrecognized projection: {proj}. Should be one of: gnomonic, orthographic, steriographic"
+        assert proj in [
+            "gnomonic",
+            "orthographic",
+            "steriographic",
+        ], f"Unrecognized projection: {proj}. Should be one of: gnomonic, orthographic, steriographic"
         WCS._projection = proj
-        
+
     @property
     def reference_radec(self):
         return self._reference_radec
+
     @reference_radec.setter
     def reference_radec(self, radec):
         WCS._reference_radec = torch.tensor(
-            radec,
-            dtype = AP_config.ap_dtype,
-            device = AP_config.ap_device
+            radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
         )
 
     @classmethod
@@ -100,8 +136,17 @@ class WCS():
           world_DEC: Declination in degrees
         """
         return (
-            torch.cos(world_DEC*deg_to_rad) * torch.sin((world_RA - cls._reference_radec[0])*deg_to_rad) * rad_to_arcsec,
-            (torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.sin(world_DEC*deg_to_rad) - torch.sin(cls._reference_radec[1]*deg_to_rad) * torch.cos(world_DEC*deg_to_rad) * torch.cos((world_RA - cls._reference_radec[0])*deg_to_rad)) * rad_to_arcsec,
+            torch.cos(world_DEC * deg_to_rad)
+            * torch.sin((world_RA - cls._reference_radec[0]) * deg_to_rad)
+            * rad_to_arcsec,
+            (
+                torch.cos(cls._reference_radec[1] * deg_to_rad)
+                * torch.sin(world_DEC * deg_to_rad)
+                - torch.sin(cls._reference_radec[1] * deg_to_rad)
+                * torch.cos(world_DEC * deg_to_rad)
+                * torch.cos((world_RA - cls._reference_radec[0]) * deg_to_rad)
+            )
+            * rad_to_arcsec,
         )
 
     @classmethod
@@ -116,8 +161,30 @@ class WCS():
           c: constant term dependent on the projection.
         """
         return (
-            (cls._reference_radec[0]*deg_to_rad + torch.arctan2(plane_x*arcsec_to_rad * torch.sin(c), rho * torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.cos(c) - plane_y*arcsec_to_rad * torch.sin(cls._reference_radec[1]*deg_to_rad) * torch.sin(c))) * rad_to_deg,
-            torch.arcsin(torch.cos(c) * torch.sin(cls._reference_radec[1]*deg_to_rad + plane_y*arcsec_to_rad * torch.sin(c) * torch.cos(cls._reference_radec[1]*deg_to_rad) / rho))*rad_to_deg,
+            (
+                cls._reference_radec[0] * deg_to_rad
+                + torch.arctan2(
+                    plane_x * arcsec_to_rad * torch.sin(c),
+                    rho * torch.cos(cls._reference_radec[1] * deg_to_rad) * torch.cos(c)
+                    - plane_y
+                    * arcsec_to_rad
+                    * torch.sin(cls._reference_radec[1] * deg_to_rad)
+                    * torch.sin(c),
+                )
+            )
+            * rad_to_deg,
+            torch.arcsin(
+                torch.cos(c)
+                * torch.sin(
+                    cls._reference_radec[1] * deg_to_rad
+                    + plane_y
+                    * arcsec_to_rad
+                    * torch.sin(c)
+                    * torch.cos(cls._reference_radec[1] * deg_to_rad)
+                    / rho
+                )
+            )
+            * rad_to_deg,
         )
 
     @classmethod
@@ -139,7 +206,13 @@ class WCS():
         See: https://mathworld.wolfram.com/GnomonicProjection.html
 
         """
-        C = torch.sin(cls._reference_radec[1]*deg_to_rad) * torch.sin(world_DEC*deg_to_rad) + torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.cos(world_DEC*deg_to_rad) * torch.cos((world_RA - cls._reference_radec[0])*deg_to_rad)
+        C = torch.sin(cls._reference_radec[1] * deg_to_rad) * torch.sin(
+            world_DEC * deg_to_rad
+        ) + torch.cos(cls._reference_radec[1] * deg_to_rad) * torch.cos(
+            world_DEC * deg_to_rad
+        ) * torch.cos(
+            (world_RA - cls._reference_radec[0]) * deg_to_rad
+        )
         x, y = cls._project_world_to_plane(world_RA, world_DEC)
         return x / C, y / C
 
@@ -160,9 +233,9 @@ class WCS():
           plane_y: tangent plane y coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
 
         See: https://mathworld.wolfram.com/GnomonicProjection.html
-        
+
         """
-        rho = torch.sqrt(plane_x**2 + plane_y**2)*arcsec_to_rad
+        rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = torch.arctan(rho)
 
         ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c)
@@ -177,7 +250,7 @@ class WCS():
         contact point. The tangent plane makes contact at the location
         of the `reference_radec` variable. The steriographic
         projection preserves circles and angle measures.
-        
+
         Args:
           world_RA: Right ascension in degrees
           world_DEC: Declination in degrees
@@ -185,7 +258,14 @@ class WCS():
         See: https://mathworld.wolfram.com/StereographicProjection.html
 
         """
-        C = (1 + torch.sin(world_DEC*deg_to_rad) * torch.sin(cls._reference_radec[1]*deg_to_rad) + torch.cos(world_DEC*deg_to_rad) * torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.cos((world_RA - cls._reference_radec[0])*deg_to_rad)) / 2
+        C = (
+            1
+            + torch.sin(world_DEC * deg_to_rad)
+            * torch.sin(cls._reference_radec[1] * deg_to_rad)
+            + torch.cos(world_DEC * deg_to_rad)
+            * torch.cos(cls._reference_radec[1] * deg_to_rad)
+            * torch.cos((world_RA - cls._reference_radec[0]) * deg_to_rad)
+        ) / 2
         x, y = cls._project_world_to_plane(world_RA, world_DEC)
         return x / C, y / C
 
@@ -197,17 +277,17 @@ class WCS():
         coordinates into (RA,DEC) coordinates. The tangent plane makes
         contact at the location of the `reference_radec` variable. The
         steriographic projection preserves circles and angle measures.
-        
+
         Args:
           plane_x: tangent plane x coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
           plane_y: tangent plane y coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
 
         See: https://mathworld.wolfram.com/StereographicProjection.html
-        
+
         """
 
-        rho = torch.sqrt(plane_x**2 + plane_y**2)*arcsec_to_rad
-        c = 2*torch.arctan(rho / 2)
+        rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
+        c = 2 * torch.arctan(rho / 2)
         ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c)
         return ra, dec
 
@@ -252,43 +332,49 @@ class WCS():
         See: https://mathworld.wolfram.com/OrthographicProjection.html
 
         """
-        rho = torch.sqrt(plane_x**2 + plane_y**2)*arcsec_to_rad
+        rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = torch.arcsin(rho)
 
-        ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c) 
+        ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c)
         return ra, dec
+
 
 if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
-    WCS.reference_radec = torch.tensor((90., 0.))
 
-    fig, axarr = plt.subplots(1,3, figsize = (18,6))
-    for proj, ax in zip(["gnomonic", "orthographic", "steriographic"],axarr):
+    WCS.reference_radec = torch.tensor((90.0, 0.0))
+
+    fig, axarr = plt.subplots(1, 3, figsize=(18, 6))
+    for proj, ax in zip(["gnomonic", "orthographic", "steriographic"], axarr):
         WCS.projection = proj
         wcs = WCS()
-        long_RA, long_DEC = torch.meshgrid(torch.linspace(90 - 1/3600, 90 + 1/3600, 24, dtype = torch.float64), torch.linspace(-1/3600, 1/3600, 1000, dtype = torch.float64), indexing = "xy")
-        
+        long_RA, long_DEC = torch.meshgrid(
+            torch.linspace(90 - 1 / 3600, 90 + 1 / 3600, 24, dtype=torch.float64),
+            torch.linspace(-1 / 3600, 1 / 3600, 1000, dtype=torch.float64),
+            indexing="xy",
+        )
+
         long_x, long_y = wcs.world_to_plane(long_RA, long_DEC)
 
-        
         ax.plot(long_x.numpy(), long_y.numpy())
         ax.set_title(proj)
     plt.tight_layout()
     plt.savefig(f"small_field_longitude.jpg")
     plt.close()
 
-    fig, axarr = plt.subplots(1,3, figsize = (18,6))
+    fig, axarr = plt.subplots(1, 3, figsize=(18, 6))
     for proj, ax in zip(["gnomonic", "orthographic", "steriographic"], axarr):
         WCS.projection = proj
         wcs = WCS()
-        long_RA, long_DEC = torch.meshgrid(torch.linspace(10, 350, 24), torch.linspace(-80, 80, 1000), indexing = "xy")
-        
+        long_RA, long_DEC = torch.meshgrid(
+            torch.linspace(10, 350, 24), torch.linspace(-80, 80, 1000), indexing="xy"
+        )
+
         long_x, long_y = wcs.world_to_plane(long_RA, long_DEC)
-        
+
         ax.plot(long_x.numpy(), long_y.numpy())
         ax.set_title(proj)
     plt.tight_layout()
     plt.savefig(f"large_field_longitude.jpg")
     plt.close()
-        

--- a/astrophot/image/wcs.py
+++ b/astrophot/image/wcs.py
@@ -688,6 +688,10 @@ class WCS(WPCS, PPCS):
     """
 
     def __init__(self, *args, wcs=None, **kwargs):
+        if kwargs.get("state", None) is not None:
+            self.set_state(kwargs["state"])
+            return
+        
         if wcs is not None:
             if wcs.wcs.ctype[0] != "RA---TAN":
                 AP_config.ap_logger.warning("Astropy WCS not tangent plane coordinate system! May not be compatable with AstroPhot.")

--- a/astrophot/image/wcs.py
+++ b/astrophot/image/wcs.py
@@ -1,0 +1,294 @@
+from abc import ABC
+import torch
+import numpy as np
+
+__all__ = ("WCS",)
+
+deg_to_rad = np.pi / 180
+rad_to_deg = 180 / np.pi
+rad_to_arcsec = rad_to_deg * 3600
+arcsec_to_rad = deg_to_rad / 3600
+
+class WCS():
+    """Class to handle WCS interpretation in AstroPhot.
+
+    AstroPhot performs it's operations on a tangent plane to the
+    sphere, this class handles projections between the sphere and the
+    tangent plane. It holds class variables for the reference (RA,DEC)
+    where the tangent plane contacts the sphere, and the type of
+    projection being performed. Note that (RA,DEC) coordinates should always be in degrees while the tangent plane is in arcsec coordinates. 
+
+    Attributes:
+      reference_radec: The reference (RA,DEC) coordinates in degrees where the tangent plane contacts the sphere.
+      projection: The projection system used to convert from (RA,DEC) onto the tangent plane. Should be one of: gnomonic (default), orthographic, steriographic
+
+    """
+
+    _reference_radec = None
+    _projection = None
+    
+    def __init__(self, *args, **kwargs):
+            
+        if self.projection is None:
+            self.projection = "gnomonic"
+        if self.reference_radec is None:
+            self.reference_radec = kwargs.get("reference_radec", (0,0))
+
+    @classmethod
+    def world_to_plane(cls, world_RA, world_DEC):
+        if cls._projection == "gnomonic":
+            return cls.world_to_plane_gnomonic(
+                torch.as_tensor(world_RA, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+                torch.as_tensor(world_DEC, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+            ) 
+        if cls._projection == "orthographic":
+            return cls.world_to_plane_orthographic(
+                torch.as_tensor(world_RA, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+                torch.as_tensor(world_DEC, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+            ) 
+        if cls._projection == "steriographic":
+            return cls.world_to_plane_steriographic(
+                torch.as_tensor(world_RA, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+                torch.as_tensor(world_DEC, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+            ) 
+        raise ValueError(f"Unrecognized projection: {cls._projection}. Should be one of: gnomonic, orthographic, steriographic")
+    @classmethod
+    def plane_to_world(cls, plane_x, plane_y):
+        if cls._projection == "gnomonic":
+            return cls.plane_to_world_gnomonic(
+                torch.as_tensor(plane_x, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+                torch.as_tensor(plane_y, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+            ) 
+        if cls._projection == "orthographic":
+            return cls.plane_to_world_orthographic(
+                torch.as_tensor(plane_x, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+                torch.as_tensor(plane_y, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+            ) 
+        if cls._projection == "steriographic":
+            return cls.plane_to_world_steriographic(
+                torch.as_tensor(plane_x, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+                torch.as_tensor(plane_y, dtype = AP_config.ap_dtype, device = AP_config.ap_device),
+            ) 
+        raise ValueError(f"Unrecognized projection: {cls._projection}. Should be one of: gnomonic, orthographic, steriographic")
+        
+    @property
+    def projection(self):
+        return self._projection
+    @projection.setter
+    def projection(self, proj):
+        assert proj in ["gnomonic", "orthographic", "steriographic"], f"Unrecognized projection: {proj}. Should be one of: gnomonic, orthographic, steriographic"
+        WCS._projection = proj
+        
+    @property
+    def reference_radec(self):
+        return self._reference_radec
+    @reference_radec.setter
+    def reference_radec(self, radec):
+        WCS._reference_radec = torch.tensor(
+            radec,
+            dtype = AP_config.ap_dtype,
+            device = AP_config.ap_device
+        )
+
+    @classmethod
+    def _project_world_to_plane(cls, world_RA, world_DEC):
+        """
+        Recurring core calculation in all the projections from world to plane.
+
+        Args:
+          world_RA: Right ascension in degrees
+          world_DEC: Declination in degrees
+        """
+        return (
+            torch.cos(world_DEC*deg_to_rad) * torch.sin((world_RA - cls._reference_radec[0])*deg_to_rad) * rad_to_arcsec,
+            (torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.sin(world_DEC*deg_to_rad) - torch.sin(cls._reference_radec[1]*deg_to_rad) * torch.cos(world_DEC*deg_to_rad) * torch.cos((world_RA - cls._reference_radec[0])*deg_to_rad)) * rad_to_arcsec,
+        )
+
+    @classmethod
+    def _project_plane_to_world(cls, plane_x, plane_y, rho, c):
+        """
+        Recurring core calculation in all the projections from plane to world.
+
+        Args:
+          plane_x: tangent plane x coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+          plane_y: tangent plane y coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+          rho: polar radius in tangent plane.
+          c: constant term dependent on the projection.
+        """
+        return (
+            (cls._reference_radec[0]*deg_to_rad + torch.arctan2(plane_x*arcsec_to_rad * torch.sin(c), rho * torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.cos(c) - plane_y*arcsec_to_rad * torch.sin(cls._reference_radec[1]*deg_to_rad) * torch.sin(c))) * rad_to_deg,
+            torch.arcsin(torch.cos(c) * torch.sin(cls._reference_radec[1]*deg_to_rad + plane_y*arcsec_to_rad * torch.sin(c) * torch.cos(cls._reference_radec[1]*deg_to_rad) / rho))*rad_to_deg,
+        )
+
+    @classmethod
+    def world_to_plane_gnomonic(cls, world_RA, world_DEC):
+        """Gnomonic projection: (RA,DEC) to tangent plane.
+
+        Performs Gnomonic projection of (RA,DEC) coordinates onto a
+        tangent plane. The origin for the tangent plane is at the
+        contact point. The tangent plane makes contact at the location
+        of the `reference_radec` variable. In a gnomonic projection,
+        great circles are mapped to straight lines. The gnomonic
+        projection represents the image formed by a spherical lens,
+        and is sometimes known as the rectilinear projection.
+
+        Args:
+          world_RA: Right ascension in degrees
+          world_DEC: Declination in degrees
+
+        See: https://mathworld.wolfram.com/GnomonicProjection.html
+
+        """
+        C = torch.sin(cls._reference_radec[1]*deg_to_rad) * torch.sin(world_DEC*deg_to_rad) + torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.cos(world_DEC*deg_to_rad) * torch.cos((world_RA - cls._reference_radec[0])*deg_to_rad)
+        x, y = cls._project_world_to_plane(world_RA, world_DEC)
+        return x / C, y / C
+
+    @classmethod
+    def plane_to_world_gnomonic(cls, plane_x, plane_y):
+        """Inverse Gnomonic projection: tangent plane to (RA,DEC).
+
+        Performs the inverse Gnomonic projection of tangent plane
+        coordinates into (RA,DEC) coordinates. The tangent plane makes
+        contact at the location of the `reference_radec` variable. In
+        a gnomonic projection, great circles are mapped to straight
+        lines. The gnomonic projection represents the image formed by
+        a spherical lens, and is sometimes known as the rectilinear
+        projection.
+
+        Args:
+          plane_x: tangent plane x coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+          plane_y: tangent plane y coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+
+        See: https://mathworld.wolfram.com/GnomonicProjection.html
+        
+        """
+        rho = torch.sqrt(plane_x**2 + plane_y**2)*arcsec_to_rad
+        c = torch.arctan(rho)
+
+        ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c)
+        return ra, dec
+
+    @classmethod
+    def world_to_plane_steriographic(cls, world_RA, world_DEC):
+        """Steriographic projection: (RA,DEC) to tangent plane
+
+        Performs Steriographic projection of (RA,DEC) coordinates onto
+        a tangent plane. The origin for the tangent plane is at the
+        contact point. The tangent plane makes contact at the location
+        of the `reference_radec` variable. The steriographic
+        projection preserves circles and angle measures.
+        
+        Args:
+          world_RA: Right ascension in degrees
+          world_DEC: Declination in degrees
+
+        See: https://mathworld.wolfram.com/StereographicProjection.html
+
+        """
+        C = (1 + torch.sin(world_DEC*deg_to_rad) * torch.sin(cls._reference_radec[1]*deg_to_rad) + torch.cos(world_DEC*deg_to_rad) * torch.cos(cls._reference_radec[1]*deg_to_rad) * torch.cos((world_RA - cls._reference_radec[0])*deg_to_rad)) / 2
+        x, y = cls._project_world_to_plane(world_RA, world_DEC)
+        return x / C, y / C
+
+    @classmethod
+    def plane_to_world_steriographic(cls, plane_x, plane_y):
+        """Inverse Steriographic projection: tangent plane to (RA,DEC).
+
+        Performs the inverse Steriographic projection of tangent plane
+        coordinates into (RA,DEC) coordinates. The tangent plane makes
+        contact at the location of the `reference_radec` variable. The
+        steriographic projection preserves circles and angle measures.
+        
+        Args:
+          plane_x: tangent plane x coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+          plane_y: tangent plane y coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+
+        See: https://mathworld.wolfram.com/StereographicProjection.html
+        
+        """
+
+        rho = torch.sqrt(plane_x**2 + plane_y**2)*arcsec_to_rad
+        c = 2*torch.arctan(rho / 2)
+        ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c)
+        return ra, dec
+
+    @classmethod
+    def world_to_plane_orthographic(cls, world_RA, world_DEC):
+        """Orthographic projection: (RA,DEC) to tangent plane
+
+        Performs Orthographic projection of (RA,DEC) coordinates onto
+        a tangent plane. The origin for the tangent plane is at the
+        contact point. The tangent plane makes contact at the location
+        of the `reference_radec` variable. The point of perspective
+        for the orthographic projection is at infinite distance. This
+        projection is perhaps better suited to represent the view of
+        an exoplanet, however it is included here for completeness.
+
+        Args:
+          world_RA: Right ascension in degrees
+          world_DEC: Declination in degrees
+
+        See: https://mathworld.wolfram.com/OrthographicProjection.html
+
+        """
+        x, y = cls._project_world_to_plane(world_RA, world_DEC)
+        return x, y
+
+    @classmethod
+    def plane_to_world_orthographic(cls, plane_x, plane_y):
+        """Inverse Orthographic projection: tangent plane to (RA,DEC).
+
+        Performs the inverse Orthographic projection of tangent plane
+        coordinates into (RA,DEC) coordinates. The tangent plane makes
+        contact at the location of the `reference_radec` variable. The
+        point of perspective for the orthographic projection is at
+        infinite distance. This projection is perhaps better suited to
+        represent the view of an exoplanet, however it is included
+        here for completeness.
+
+        Args:
+          plane_x: tangent plane x coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+          plane_y: tangent plane y coordinate in arcseconds. The origin of the tangent plane is the contact point with the sphere, represented by `reference_radec`.
+
+        See: https://mathworld.wolfram.com/OrthographicProjection.html
+
+        """
+        rho = torch.sqrt(plane_x**2 + plane_y**2)*arcsec_to_rad
+        c = torch.arcsin(rho)
+
+        ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c) 
+        return ra, dec
+
+if __name__ == "__main__":
+
+    import matplotlib.pyplot as plt
+    WCS.reference_radec = torch.tensor((90., 0.))
+
+    fig, axarr = plt.subplots(1,3, figsize = (18,6))
+    for proj, ax in zip(["gnomonic", "orthographic", "steriographic"],axarr):
+        WCS.projection = proj
+        wcs = WCS()
+        long_RA, long_DEC = torch.meshgrid(torch.linspace(90 - 1/3600, 90 + 1/3600, 24, dtype = torch.float64), torch.linspace(-1/3600, 1/3600, 1000, dtype = torch.float64), indexing = "xy")
+        
+        long_x, long_y = wcs.world_to_plane(long_RA, long_DEC)
+
+        
+        ax.plot(long_x.numpy(), long_y.numpy())
+        ax.set_title(proj)
+    plt.tight_layout()
+    plt.savefig(f"small_field_longitude.jpg")
+    plt.close()
+
+    fig, axarr = plt.subplots(1,3, figsize = (18,6))
+    for proj, ax in zip(["gnomonic", "orthographic", "steriographic"], axarr):
+        WCS.projection = proj
+        wcs = WCS()
+        long_RA, long_DEC = torch.meshgrid(torch.linspace(10, 350, 24), torch.linspace(-80, 80, 1000), indexing = "xy")
+        
+        long_x, long_y = wcs.world_to_plane(long_RA, long_DEC)
+        
+        ax.plot(long_x.numpy(), long_y.numpy())
+        ax.set_title(proj)
+    plt.tight_layout()
+    plt.savefig(f"large_field_longitude.jpg")
+    plt.close()
+        

--- a/astrophot/image/wcs.py
+++ b/astrophot/image/wcs.py
@@ -206,7 +206,6 @@ class WCS:
         See: https://mathworld.wolfram.com/GnomonicProjection.html
 
         """
-        print("w2p gnomonic", cls._reference_radec.numpy())
         C = torch.sin(cls._reference_radec[1] * deg_to_rad) * torch.sin(
             world_DEC * deg_to_rad
         ) + torch.cos(cls._reference_radec[1] * deg_to_rad) * torch.cos(
@@ -236,7 +235,6 @@ class WCS:
         See: https://mathworld.wolfram.com/GnomonicProjection.html
 
         """
-        print("p2w gnomonic", cls._reference_radec.numpy())
         rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = torch.arctan(rho)
 
@@ -260,7 +258,6 @@ class WCS:
         See: https://mathworld.wolfram.com/StereographicProjection.html
 
         """
-        print("w2p steriographic")
         C = (
             1
             + torch.sin(world_DEC * deg_to_rad)
@@ -288,8 +285,6 @@ class WCS:
         See: https://mathworld.wolfram.com/StereographicProjection.html
 
         """
-        print("p2w steriographic")
-
         rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = 2 * torch.arctan(rho / 2)
         ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c)
@@ -314,8 +309,6 @@ class WCS:
         See: https://mathworld.wolfram.com/OrthographicProjection.html
 
         """
-        print("w2p orthographic")
-
         x, y = cls._project_world_to_plane(world_RA, world_DEC)
         return x, y
 
@@ -338,50 +331,8 @@ class WCS:
         See: https://mathworld.wolfram.com/OrthographicProjection.html
 
         """
-        print("p2w orthographic")
         rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = torch.arcsin(rho)
 
         ra, dec = cls._project_plane_to_world(plane_x, plane_y, rho, c)
         return ra, dec
-
-
-if __name__ == "__main__":
-
-    import matplotlib.pyplot as plt
-
-    WCS.reference_radec = torch.tensor((90.0, 0.0))
-
-    fig, axarr = plt.subplots(1, 3, figsize=(18, 6))
-    for proj, ax in zip(["gnomonic", "orthographic", "steriographic"], axarr):
-        WCS.projection = proj
-        wcs = WCS()
-        long_RA, long_DEC = torch.meshgrid(
-            torch.linspace(90 - 1 / 3600, 90 + 1 / 3600, 24, dtype=torch.float64),
-            torch.linspace(-1 / 3600, 1 / 3600, 1000, dtype=torch.float64),
-            indexing="xy",
-        )
-
-        long_x, long_y = wcs.world_to_plane(long_RA, long_DEC)
-
-        ax.plot(long_x.numpy(), long_y.numpy())
-        ax.set_title(proj)
-    plt.tight_layout()
-    plt.savefig(f"small_field_longitude.jpg")
-    plt.close()
-
-    fig, axarr = plt.subplots(1, 3, figsize=(18, 6))
-    for proj, ax in zip(["gnomonic", "orthographic", "steriographic"], axarr):
-        WCS.projection = proj
-        wcs = WCS()
-        long_RA, long_DEC = torch.meshgrid(
-            torch.linspace(10, 350, 24), torch.linspace(-80, 80, 1000), indexing="xy"
-        )
-
-        long_x, long_y = wcs.world_to_plane(long_RA, long_DEC)
-
-        ax.plot(long_x.numpy(), long_y.numpy())
-        ax.set_title(proj)
-    plt.tight_layout()
-    plt.savefig(f"large_field_longitude.jpg")
-    plt.close()

--- a/astrophot/image/wcs.py
+++ b/astrophot/image/wcs.py
@@ -33,7 +33,7 @@ class WCS:
     def __init__(self, *args, **kwargs):
 
         if self.projection is None:
-            self.projection = "gnomonic"
+            self.projection = kwargs.get("projection", "gnomonic")
         if self.reference_radec is None:
             self.reference_radec = kwargs.get("reference_radec", (0, 0))
 
@@ -177,12 +177,12 @@ class WCS:
                 torch.cos(c)
                 * torch.sin(
                     cls._reference_radec[1] * deg_to_rad
-                    + plane_y
-                    * arcsec_to_rad
-                    * torch.sin(c)
-                    * torch.cos(cls._reference_radec[1] * deg_to_rad)
-                    / rho
                 )
+                + plane_y
+                * arcsec_to_rad
+                * torch.sin(c)
+                * torch.cos(cls._reference_radec[1] * deg_to_rad)
+                / rho
             )
             * rad_to_deg,
         )
@@ -206,6 +206,7 @@ class WCS:
         See: https://mathworld.wolfram.com/GnomonicProjection.html
 
         """
+        print("w2p gnomonic", cls._reference_radec.numpy())
         C = torch.sin(cls._reference_radec[1] * deg_to_rad) * torch.sin(
             world_DEC * deg_to_rad
         ) + torch.cos(cls._reference_radec[1] * deg_to_rad) * torch.cos(
@@ -235,6 +236,7 @@ class WCS:
         See: https://mathworld.wolfram.com/GnomonicProjection.html
 
         """
+        print("p2w gnomonic", cls._reference_radec.numpy())
         rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = torch.arctan(rho)
 
@@ -258,6 +260,7 @@ class WCS:
         See: https://mathworld.wolfram.com/StereographicProjection.html
 
         """
+        print("w2p steriographic")
         C = (
             1
             + torch.sin(world_DEC * deg_to_rad)
@@ -285,6 +288,7 @@ class WCS:
         See: https://mathworld.wolfram.com/StereographicProjection.html
 
         """
+        print("p2w steriographic")
 
         rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = 2 * torch.arctan(rho / 2)
@@ -310,6 +314,8 @@ class WCS:
         See: https://mathworld.wolfram.com/OrthographicProjection.html
 
         """
+        print("w2p orthographic")
+
         x, y = cls._project_world_to_plane(world_RA, world_DEC)
         return x, y
 
@@ -332,6 +338,7 @@ class WCS:
         See: https://mathworld.wolfram.com/OrthographicProjection.html
 
         """
+        print("p2w orthographic")
         rho = torch.sqrt(plane_x ** 2 + plane_y ** 2) * arcsec_to_rad
         c = torch.arcsin(rho)
 

--- a/astrophot/image/wcs.py
+++ b/astrophot/image/wcs.py
@@ -1,4 +1,3 @@
-from abc import ABC
 import torch
 import numpy as np
 
@@ -15,7 +14,7 @@ arcsec_to_rad = deg_to_rad / 3600
 class WPCS:
     """World to Plane Coordinate System in AstroPhot.
 
-    AstroPhot performs it's operations on a tangent plane to the
+    AstroPhot performs its operations on a tangent plane to the
     celestial sphere, this class handles projections between the sphere and the
     tangent plane. It holds variables for the reference (RA,DEC) where
     the tangent plane contacts the sphere, and the type of projection
@@ -29,7 +28,7 @@ class WPCS:
 
     """
 
-    # Softening length used for numerical stability and/or integration stability to avoid discontinuities (near R=0)
+    # Softening length used for numerical stability and/or integration stability to avoid discontinuities (near R=0). This is in units of arcsec.
     softening = 1e-3
     
     default_reference_radec = (0,0)
@@ -43,7 +42,7 @@ class WPCS:
         
         
     def world_to_plane(self, world_RA, world_DEC=None):
-        """Take a coordinate on the world coordiante system, also called the
+        """Take a coordinate on the world coordinate system, also called the
         celesial sphere, (RA, DEC in degrees) and transform it to the
         cooresponding tangent plane coordinate
         (arcsec). Transformation is done based on the chosen
@@ -153,7 +152,7 @@ class WPCS:
     @property
     def reference_radec(self):
         """
-        RA DEC (world) coordiantes where the tangent plane meets the celestial sphere. These should be in degrees.
+        RA DEC (world) coordinates where the tangent plane meets the celestial sphere. These should be in degrees.
         """
         return self._reference_radec
 
@@ -165,7 +164,7 @@ class WPCS:
     @property
     def reference_planexy(self):
         """
-        x y tangent plane coordiantes where the tangent plane meets the celestial sphere. These should be in arcsec.
+        x y tangent plane coordinates where the tangent plane meets the celestial sphere. These should be in arcsec.
         """
         return self._reference_planexy
 
@@ -397,7 +396,7 @@ class WPCS:
 
     def get_fits_state(self):
         """
-        Similar to get_state, except specifically tailored to be stored in a fits format.
+        Similar to get_state, except specifically tailored to be stored in a FITS format.
         """
         return {
             "PROJ": self.projection,
@@ -546,7 +545,7 @@ class PPCS:
 
     @property
     def reference_imageij(self):
-        """pixel coordiantes where the pixel grid is fixed to the tangent
+        """pixel coordinates where the pixel grid is fixed to the tangent
         plane. These should be in pixel units where (0,0) is the
         center of the [0,0] indexed pixel. However, it is still in xy
         format, meaning that the first index gives translations in the
@@ -562,7 +561,7 @@ class PPCS:
         )
     @property
     def reference_imagexy(self):
-        """plane coordiantes where the image grid is fixed to the tangent
+        """plane coordinates where the image grid is fixed to the tangent
         plane. These should be in arcsec.
 
         """
@@ -577,12 +576,12 @@ class PPCS:
     def pixel_to_plane(self, pixel_i, pixel_j=None):
         """Take in a coordinate on the regular pixel grid, where 0,0 is the
         center of the [0,0] indexed pixel. This coordinate is
-        transformed into the tangent plane coordiante system (arcsec)
+        transformed into the tangent plane coordinate system (arcsec)
         based on the pixel scale and reference positions. If the pixel
         scale matrix is :math:`P`, the reference pixel is
         :math:`\vec{r}_{pix}`, the reference tangent plane point is
         :math:`\vec{r}_{tan}`, and the coordinate to transform is
-        :math:`\vec{c}_{pix}` then the coordiante in the tangent plane
+        :math:`\vec{c}_{pix}` then the coordinate in the tangent plane
         is:
 
         .. math::
@@ -602,7 +601,7 @@ class PPCS:
         scale matrix is :math:`P`, the reference pixel is
         :math:`\vec{r}_{pix}`, the reference tangent plane point is
         :math:`\vec{r}_{tan}`, and the coordinate to transform is
-        :math:`\vec{c}_{tan}` then the coordiante in the pixel grid
+        :math:`\vec{c}_{tan}` then the coordinate in the pixel grid
         is:
 
         .. math::
@@ -699,10 +698,10 @@ class WCS(WPCS, PPCS):
                 AP_config.ap_logger.warning("Astropy WCS not tangent plane coordinate system! May not be compatable with AstroPhot.")
                 
         if wcs is not None:
-            sky_coord = wcs.pixel_to_world(*wcs.wcs.crpix)
-            kwargs["reference_radec"] = kwargs.get("reference_radec", (sky_coord.ra.deg, sky_coord.dec.deg))
+            kwargs["reference_radec"] = kwargs.get("reference_radec", wcs.wcs.crval)
             kwargs["reference_imageij"] = wcs.wcs.crpix
             WPCS.__init__(self, *args, wcs=wcs, **kwargs)
+            sky_coord = wcs.pixel_to_world(*wcs.wcs.crpix)
             kwargs["reference_imagexy"] = self.world_to_plane(torch.tensor((sky_coord.ra.deg, sky_coord.dec.deg), dtype=AP_config.ap_dtype, device=AP_config.ap_device))
         else:
             WPCS.__init__(self, *args, **kwargs)

--- a/astrophot/image/wcs.py
+++ b/astrophot/image/wcs.py
@@ -16,9 +16,10 @@ class WCS:
 
     AstroPhot performs it's operations on a tangent plane to the
     sphere, this class handles projections between the sphere and the
-    tangent plane. It holds class variables for the reference (RA,DEC)
-    where the tangent plane contacts the sphere, and the type of
-    projection being performed. Note that (RA,DEC) coordinates should always be in degrees while the tangent plane is in arcsec coordinates.
+    tangent plane. It holds variables for the reference (RA,DEC) where
+    the tangent plane contacts the sphere, and the type of projection
+    being performed. Note that (RA,DEC) coordinates should always be
+    in degrees while the tangent plane is in arcsec coordinates.
 
     Attributes:
       reference_radec: The reference (RA,DEC) coordinates in degrees where the tangent plane contacts the sphere.

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -532,14 +532,14 @@ class Window_List(Window):
         """
         ref = torch.stack(tuple(W.reference_radec for W in filter(lambda w: w is not None, self.window_list)))
         if not torch.allclose(ref, ref[0]):
-            AP_config.error("Reference (world) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference (world) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
         ref = torch.stack(tuple(W.reference_planexy for W in filter(lambda w: w is not None, self.window_list)))
         if not torch.allclose(ref, ref[0]):
-            AP_config.error("Reference (tangent plane) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference (tangent plane) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
         if len(set(W.projection for W in filter(lambda w: w is not None, self.window_list))) > 1:
-            AP_config.error("Projection missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Projection missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
             
             
     @property

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -3,12 +3,12 @@ import torch
 
 from .. import AP_config
 from ..utils.conversions.coordinates import Rotate_Cartesian
-from .wcs import WCS
+from .wcs import WPCS
 
 __all__ = ["Window", "Window_List"]
 
 
-class Window(WCS):
+class Window(WPCS):
     """class to define a window on the sky in coordinate space. These
     windows can undergo arithmetic an preserve logical behavior. Image
     objects can also be indexed using windows and will return an

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -3,25 +3,61 @@ import torch
 
 from .. import AP_config
 from ..utils.conversions.coordinates import Rotate_Cartesian
-from .wcs import WPCS
+from .wcs import WCS
 
 __all__ = ["Window", "Window_List"]
 
-
-class Window(WPCS):
+class Window(WCS):
     """class to define a window on the sky in coordinate space. These
     windows can undergo arithmetic an preserve logical behavior. Image
     objects can also be indexed using windows and will return an
     appropriate subsection of their data.
 
+    There are several ways to tell a Window object where to
+    place itself. The simplest method is to pass an
+    Astropy WCS object such as::
+
+      H = ap.image.Window(
+          data_shape = data.shape,
+          wcs = wcs,
+      )
+
+    this will automatically place your image at the correct RA, DEC
+    and assign the correct pixel scale. WARNING, it will default to
+    setting the reference RA DEC at the reference RA DEC of the wcs
+    object; if you have multiple images you should force them all to
+    have the same reference world coordiante by passing
+    ``reference_radec = (ra, dec)``. See the :doc:`coordinates`
+    documentation for more details. There are several other ways to
+    initialize the image header. If you provide ``origin_radec`` then
+    it will place the image origin at the requested RA DEC
+    coordinates. If you provide ``center_radec`` then it will place
+    the image center at the requested RA DEC coordiantes. Note that in
+    these cases the fixed point between the pixel grid and image plane
+    is different (pixel origin and center respectively); so if you
+    have rotated pixels in your pixel scale matrix then everything
+    will be rotated about different points (pixel origin and center
+    respectively). If you provide ``origin`` or ``center`` then those
+    are coordiantes in the tangent plane (arcsec) and they will
+    correspondingly become fixed points. For arbitrary control over
+    the pixel positioning, use ``reference_imageij`` and
+    ``reference_imagexy`` to fix the pixel and tangent plane
+    coordinates respectively to each other, any rotation or shear will
+    happen about that fixed point.
+    
     Args:
-      origin: the position of the bottom left corner of the window. Note that for an image, the origin corresponds to the pixel location -0.5, -0.5 since the pixel coordinates have zero at the center of the pixel while the on sky bounding box should include the size of the pixels as well and so will be half a pixel width shifted. [arcsec]
-      origin_radec: The position of outer corner of the (0,0) pixel given as Right Ascention and Declination (RA, DEC) in degrees. The most straightforward usage of `origin_radec` is to call `C = wcs.pixel_to_world(-0.5,-0.5)` which will give a SkyCoord object, then call `origin_radec = (C.ra.deg, C.dec.deg)` as an argument to the target image. **Note** see also `reference_radec`.
-      shape: the length of the sides of the window in physical units [arcsec]
-      pixelshape: A det = 1 matrix which describes the projection of coordinates on the sky. If nothing is given then an identity matrix is assumed. If a wcs object is given then the projection is the pixel scale matrix normalized to determinant of 1. Essentially this matrix described the transformation from a simple cartesian grid onto the sky which may be flipped, rotated or streched. [unitless 2x2 matrix]
-      center: Instead of providing the origin, one can provide the center position. This will just be used to update the origin. [arcsec]
-      center_radec: Similar to `origin_radec` one may provide the RA and DEC of the center of the image in degrees. **Note** see also `reference_radec` below.
-      state: A dictionary containing the origin, shape, and orientation information. [dict]
+      origin : Sequence or None, optional
+          The origin of the image in the tangent plane coordinate system
+          (arcsec), as a 1D array of length 2. Default is None.
+      origin_radec : Sequence or None, optional
+          The origin of the image in the world coordinate system (RA,
+          DEC in degrees), as a 1D array of length 2. Default is None.
+      center : Sequence or None, optional
+          The center of the image in the tangent plane coordinate system
+          (arcsec), as a 1D array of length 2. Default is None.
+      center_radec : Sequence or None, optional
+          The center of the image in the world coordinate system (RA,
+          DEC in degrees), as a 1D array of length 2. Default is None.
       wcs: An astropy.wcs.wcs.WCS object which gives information about the origin and orientation of the window.
       reference_radec: AstroPhot works on a tangent plane where everything is nice and linear, but the sky is a sphere. The worst case would be an image where one of the poles lies inside the image and there is a singularity in the coordinate system. In RA and DEC the approximation works best at `RA = 0`, `DEC = 0` (or really anywhere on the equator). This "good spot" for the coordinates is just an artifact of where we choose to put our coordinates, hence the pole singularity is also artificial. The `reference_radec` is an (RA, DEC) coordinate which can be used to re-orient the polar coordinates so that the "good spot" is anywhere you want. This all happens internally and you should not have to worry about it.
     """
@@ -29,10 +65,9 @@ class Window(WPCS):
     def __init__(
         self,
         *,
+        pixel_shape=None,
         origin=None,
         origin_radec=None,
-        shape=None,
-        pixelshape=None,
         center=None,
         center_radec=None,
         state=None,
@@ -41,103 +76,110 @@ class Window(WPCS):
     ):
         # If loading from a previous state, simply update values and end init
         if state is not None:
-            self.update_state(state)
+            self.set_state(state)
             return
-
-        if pixelshape is not None:  # Pixelshape matrix provided
-            pixelshape = torch.as_tensor(
-                pixelshape, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            # normalize determinant to area of 1
-            self.pixelshape = pixelshape / torch.linalg.det(pixelshape).abs().sqrt()
-        elif wcs is not None:  # Pixelshape matrix from WCS
-            proj = wcs.pixel_scale_matrix
-            proj /= np.sqrt(np.abs(np.linalg.det(proj)))
-            self.pixelshape = torch.tensor(
-                proj, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-        else:  # Pixelshape matrix assumed to be identity
-            self.pixelshape = torch.eye(
-                2, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-
-        self.shape = torch.as_tensor(
-            shape, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-
-        # Determine origin
-        if origin_radec is not None:
+        
+        # Collect the shape of the window
+        assert pixel_shape is not None, "Window must know pixel shape of region (how many pixels on each side)"
+        self.pixel_shape = pixel_shape
+            
+        # Determine relative positioning of tangent plane and pixel grid. Also world coordinates and tangent plane
+        assert sum(C is not None for C in [wcs, origin_radec, center_radec, origin, center]) <= 1, "Please provide only one reference position for the window, otherwise the placement is ambiguous"
+        # Image coordinates provided by WCS
+        if wcs is not None:
+            super().__init__(wcs=wcs, **kwargs)
+        # Image reference position from RA and DEC of image origin
+        elif origin_radec is not None:  
+            # Origin given, it is reference point
             origin_radec = torch.as_tensor(
                 origin_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
             kwargs["reference_radec"] = kwargs.get("reference_radec", origin_radec)
             super().__init__(**kwargs)
-            self.origin = torch.stack(self.world_to_plane(*origin_radec))
+            self.reference_imageij = (-0.5,-0.5)
+            self.reference_imagexy = self.world_to_plane(origin_radec)
+        # Image reference position from RA and DEC of image center
         elif center_radec is not None:
+            pix_center = self.pixel_shape.to(dtype=AP_config.ap_dtype) / 2 - 0.5
             center_radec = torch.as_tensor(
                 center_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
             kwargs["reference_radec"] = kwargs.get("reference_radec", center_radec)
             super().__init__(**kwargs)
-            self.center = torch.stack(self.world_to_plane(*center_radec))
+            center = self.world_to_plane(center_radec)
+            self.reference_imageij = pix_center
+            self.reference_imagexy = center
+        # Image reference position from tangent plane position of image origin
         elif origin is not None:
-            self.origin = torch.as_tensor(
-                origin, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
+            kwargs.update({
+                "reference_imageij": (-0.5,-0.5),
+                "reference_imagexy": origin,
+            })
             super().__init__(**kwargs)
+        # Image reference position from tangent plane position of image center
         elif center is not None:
-            self.center = torch.as_tensor(
-                center, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
+            pix_center = self.pixel_shape.to(dtype=AP_config.ap_dtype) / 2 - 0.5
+            kwargs.update({
+                "reference_imageij": pix_center,
+                "reference_imagexy": center,                
+            })
             super().__init__(**kwargs)
-        elif wcs is not None:
-            wcs_origin = wcs.pixel_to_world(-0.5, -0.5)
-            wcs_origin = torch.as_tensor(
-                [wcs_origin.ra.deg, wcs_origin.dec.deg],
-                dtype=AP_config.ap_dtype,
-                device=AP_config.ap_device,
-            )
-            kwargs["reference_radec"] = kwargs.get("reference_radec", wcs_origin)
-            super().__init__(**kwargs)
-            self.origin = torch.stack(self.world_to_plane(*wcs_origin))
+        # Image origin assumed to be at tangent plane origin
         else:
-            raise ValueError(
-                "One of center or origin must be provided to create window"
-            )
-
+            super().__init__(**kwargs)
+        
+    @property
+    def shape(self):
+        S1 = self.pixel_shape.to(dtype=AP_config.ap_dtype)
+        S1[1] = 0.
+        S2 = self.pixel_shape.to(dtype=AP_config.ap_dtype)
+        S2[0] = 0.
+        return torch.stack((
+            torch.linalg.norm(self.pixelscale @ S1),
+            torch.linalg.norm(self.pixelscale @ S2),
+        ))
+    @shape.setter
+    def shape(self, shape):
+        if shape is None:
+            self._pixel_shape = None
+            return
+        shape = torch.as_tensor(
+            shape, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+        )
+        self.pixel_shape = shape / torch.sqrt(torch.sum(self.pixelscale**2, dim = 0))
+        
+    @property
+    def pixel_shape(self):
+        return self._pixel_shape
+    @pixel_shape.setter
+    def pixel_shape(self, shape):
+        if shape is None:
+            self._pixel_shape = None
+            return
+        self._pixel_shape = torch.as_tensor(
+            shape, device=AP_config.ap_device
+        )
+        self._pixel_shape = torch.round(self.pixel_shape).to(dtype=torch.int32, device=AP_config.ap_device)
+        
     @property
     def end(self):
-        return self.cartesian_to_plane(self.shape)
+        return self.pixel_to_plane_delta(self.pixel_shape.to(dtype=AP_config.ap_dtype))
 
+    @property
+    def origin(self):
+        return self.pixel_to_plane(-0.5*torch.ones_like(self.reference_imageij))
+    
     @property
     def center(self):
         return self.origin + self.end / 2
-
-    @center.setter
-    def center(self, c):
-        self.origin = (
-            torch.as_tensor(c, dtype=AP_config.ap_dtype, device=AP_config.ap_device)
-            - self.end / 2
-        )
-
-    def plane_to_cartesian(self, plane_coordinate):
-        """Projects a tangent plane coordinate which may be rotated, flipped, or
-        sheered into a regular square cartesian grid for the purpose
-        of comparisons and where arithmetic is more straightforward.
-
-        """
-        return torch.linalg.solve(self.pixelshape, plane_coordinate)
-
-    def cartesian_to_plane(self, cartesian_coordinate):
-        return self.pixelshape @ cartesian_coordinate
-
-    def copy(self):
-        return self.__class__(
-            origin=torch.clone(self.origin),
-            shape=torch.clone(self.shape),
-            pixelshape=torch.clone(self.pixelshape),
-            projection=self.projection,
-            reference_radec=self.reference_radec,
+    
+    def copy(self, **kwargs):
+        copy_kwargs = {
+            "pixel_shape": torch.clone(self.pixel_shape)
+        }
+        copy_kwargs.update(kwargs)
+        return super().copy(
+            **copy_kwargs
         )
 
     def to(self, dtype=None, device=None):
@@ -146,54 +188,77 @@ class Window(WPCS):
         if device is None:
             device = AP_config.ap_device
         super().to(dtype=dtype, device=device)
-        self.shape = self.shape.to(dtype=dtype, device=device)
-        self.origin = self.origin.to(dtype=dtype, device=device)
-        self.pixelshape = self.pixelshape.to(dtype=dtype, device=device)
+        self.pixel_shape = self.pixel_shape.to(dtype=dtype, device=device)
 
-    def get_shape(self, pixelscale):
-        return (torch.round(torch.linalg.solve(pixelscale, self.end).abs())).int()
+    # def get_shape(self, pixelscale):
+    #     return (torch.round(torch.linalg.solve(pixelscale, self.end).abs())).int()
 
-    def get_shape_flip(self, pixelscale):
-        return torch.flip(self.get_shape(pixelscale), (0,))
+    # def get_shape_flip(self, pixelscale):
+    #     return torch.flip(self.get_shape(pixelscale), (0,))
+
+    def rescale(self, scale, **kwargs):
+        return self.copy(
+            pixelscale = self.pixelscale / scale,
+            pixel_shape = self.pixel_shape * scale,
+            reference_imageij=(self.reference_imageij + 0.5)*scale - 0.5,
+            **kwargs,
+        )
 
     @torch.no_grad()
-    def _get_indices(self, obj_window, obj_pixelscale):
-        """
-        Return an index slicing tuple for obj corresponding to this window
-        """
-        unclipped_start = torch.round(
-            torch.linalg.solve(obj_pixelscale, (self.origin - obj_window.origin))
-        ).int()
-        unclipped_end = torch.round(
-            torch.linalg.solve(
-                obj_pixelscale, (self.origin + self.end - obj_window.origin)
-            )
-        ).int()
-        clipping_end = torch.round(
-            torch.linalg.solve(obj_pixelscale, obj_window.end)
-        ).int()
-        return (
-            slice(
-                torch.max(
-                    torch.tensor(0, dtype=torch.int, device=AP_config.ap_device),
-                    unclipped_start[1],
-                ),
-                torch.min(clipping_end[1], unclipped_end[1]),
-            ),
-            slice(
-                torch.max(
-                    torch.tensor(0, dtype=torch.int, device=AP_config.ap_device),
-                    unclipped_start[0],
-                ),
-                torch.min(clipping_end[0], unclipped_end[0]),
-            ),
-        )
+    def _get_indices(self, obj_window):
+        other_origin_pix = torch.round(self.plane_to_pixel(obj_window.origin) + 0.5).int()
+        new_origin_pix = torch.maximum(torch.zeros_like(other_origin_pix), other_origin_pix)
+
+        other_pixel_end = torch.round(self.plane_to_pixel(obj_window.origin + obj_window.end) + 0.5).int()
+        new_pixel_end = torch.minimum(self.pixel_shape, other_pixel_end)
+        return slice(new_origin_pix[1], new_pixel_end[1]), slice(new_origin_pix[0], new_pixel_end[0])
+
+        # low = torch.round(self.plane_to_pixel_delta(self.reference_imagexy - obj_window.reference_imagexy) + self.reference_imageij - obj_window.reference_imageij).int()
+        # high = torch.round(self.plane_to_pixel_delta(self.reference_imagexy + self.end - obj_window.reference_imagexy) + self.reference_imageij - obj_window.reference_imageij).int()
+        # max_pix = torch.round(self.plane_to_pixel_delta(obj_window.end)).int()
+        # print(low, high, max_pix)
+        # limits = torch.clamp(torch.stack((low, high)), min=torch.zeros_like(high), max=high)
+        # print(limits)
+        # return slice(limits[0][1], limits[1][1]), slice(limits[0][0], limits[1][0])
+        
+    # @torch.no_grad()
+    # def _get_indices(self, obj_window, obj_pixelscale):
+    #     """
+    #     Return an index slicing tuple for obj corresponding to this window
+    #     """
+    #     unclipped_start = torch.round(
+    #         torch.linalg.solve(obj_pixelscale, (self.origin - obj_window.origin))
+    #     ).int()
+    #     unclipped_end = torch.round(
+    #         torch.linalg.solve(
+    #             obj_pixelscale, (self.origin + self.end - obj_window.origin)
+    #         )
+    #     ).int()
+    #     clipping_end = torch.round(
+    #         torch.linalg.solve(obj_pixelscale, obj_window.end)
+    #     ).int()
+    #     return (
+    #         slice(
+    #             torch.max(
+    #                 torch.tensor(0, dtype=torch.int, device=AP_config.ap_device),
+    #                 unclipped_start[1],
+    #             ),
+    #             torch.min(clipping_end[1], unclipped_end[1]),
+    #         ),
+    #         slice(
+    #             torch.max(
+    #                 torch.tensor(0, dtype=torch.int, device=AP_config.ap_device),
+    #                 unclipped_start[0],
+    #             ),
+    #             torch.min(clipping_end[0], unclipped_end[0]),
+    #         ),
+    #     )
 
     def get_indices(self, obj):
         """
         Return an index slicing tuple for obj corresponding to this window
         """
-        return self._get_indices(obj.window, obj.pixelscale)
+        return self._get_indices(obj.window)
 
     def overlap_frac(self, other):
         overlap = self & other
@@ -201,368 +266,473 @@ class Window(WPCS):
         full_area = torch.prod(self.shape) + torch.prod(other.shape) - overlap_area
         return overlap_area / full_area
 
-    def shift_origin(self, shift):
+    def shift(self, shift):
         """
-        Shift the origin of the window by a specified amount in tangent plane coordinates
+        Shift the location of the window by a specified amount in tangent plane coordinates
         """
-        self.origin += shift
+        self.reference_imagexy = self.reference_imagexy + shift
+        return self
+
+    def pixel_shift(self, shift):
+        """
+        Shift the location of the window by a specified amount in pixel grid coordinates
+        """
+
+        self.reference_imageij = self.reference_imageij - shift
         return self
 
     def get_state(self):
-        state = {
-            "origin": tuple(self.origin.detach().cpu().tolist()),
-            "shape": tuple(self.shape.detach().cpu().tolist()),
-            "pixelshape": tuple(tuple(p) for p in self.pixelshape.detach().tolist()),
-            "projection": self.projection,
-            "reference_radec": tuple(self.reference_radec.detach().cpu().tolist()),
-        }
+        state = super().get_state()
+        state["pixel_shape"] = tuple(self.pixel_shape.detach().cpu().tolist())
         return state
 
-    def update_state(self, state):
-        self.origin = torch.tensor(
-            state["origin"], dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    def set_state(self, state):
+        super().set_state(state)
+        self.pixel_shape = torch.tensor(
+            state["pixel_shape"], dtype=AP_config.ap_dtype, device=AP_config.ap_device
         )
-        self.shape = torch.tensor(
-            state["shape"], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-        self.pixelshape = torch.tensor(
-            state["pixelshape"], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-        self.projection = state["projection"] # fixme move to WCS object
-        self.reference_radec = state["reference_radec"]
 
-    # Window adjustment operators
+    def crop_pixel(self, pixels):
+        """
+        [crop all sides] or
+        [crop x, crop y] or
+        [crop x low, crop y low, crop x high, crop y high]
+        """
+        if len(pixels) == 1:
+            self.pixel_shape = self.pixel_shape - 2*pixels[0]
+            self.reference_imageij = self.reference_imageij - pixels[0]
+        elif len(pixels) == 2:
+            pix_shift = torch.as_tensor(
+                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+            )
+            self.pixel_shape = self.pixel_shape - 2*pix_shift
+            self.reference_imageij = self.reference_imageij - pix_shift
+        elif len(pixels) == 4:  # different crop on all sides
+            pixels = torch.as_tensor(
+                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+            )
+            self.pixel_shape = self.pixel_shape - pixels[::2] - pixels[1::2]
+            self.reference_imageij = self.reference_imageij - pixels[::2]
+        else:
+            raise ValueError(f"Unrecognized pixel crop format: {pixels}")
+        return self
+
+    def crop_to_pixel(self, pixels):
+        """
+        format: [[xmin, xmax],[ymin,ymax]]
+        """
+        pixels = torch.tensor(pixels,dtype=AP_config.ap_dtype, device=AP_config.ap_device)
+        self.reference_imageij = self.reference_imageij - pixels[:,0]
+        self.pixel_shape = pixels[:,1] - pixels[:,0]
+        return self
+
+    def pad_pixel(self, pixels):
+        """
+        [pad all sides] or
+        [pad x, pad y] or
+        [pad x low, pad y low, pad x high, pad y high]
+        """
+        if len(pixels) == 1:
+            self.pixel_shape = self.pixel_shape + 2*pixels[0]
+            self.reference_imageij = self.reference_imageij + pixels[0]
+        elif len(pixels) == 2:
+            pix_shift = torch.as_tensor(
+                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+            )
+            self.pixel_shape = self.pixel_shape + 2*pix_shift
+            self.reference_imageij = self.reference_imageij + pix_shift
+        elif len(pixels) == 4:  # different crop on all sides
+            pixels = torch.as_tensor(
+                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+            )
+            self.pixel_shape = self.pixel_shape + pixels[::2] + pixels[1::2]
+            self.reference_imageij = self.reference_imageij + pixels[::2]
+        else:
+            raise ValueError(f"Unrecognized pixel crop format: {pixels}")
+        return self
+
     @torch.no_grad()
-    def __add__(self, other):
-        """Add to the size of the window. This operation preserves the window
-        center and changes the size (shape) of the window by
-        increasing the border.
+    def get_coordinate_meshgrid(self):
+        """Returns a meshgrid with tangent plane coordinates for the center
+        of every pixel.
 
         """
-        if isinstance(other, (float, int, torch.dtype)):
-            new_shape = self.shape + 2 * other
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            new_shape = self.shape + 2 * torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        raise ValueError(f"Window object cannot be added with {type(other)}")
+        pix = self.pixel_shape.to(dtype=AP_config.ap_dtype)
+        xsteps = torch.arange(
+            pix[0], dtype=AP_config.ap_dtype, device=AP_config.ap_device
+        )
+        ysteps = torch.arange(
+            pix[1], dtype=AP_config.ap_dtype, device=AP_config.ap_device
+        )
+        meshx, meshy = torch.meshgrid(
+            xsteps,
+            ysteps,
+            indexing="xy",
+        )
+        Coords = self.pixel_to_plane(meshx, meshy)
+        return torch.stack(Coords)
 
     @torch.no_grad()
-    def __iadd__(self, other):
-        if isinstance(other, (float, int, torch.dtype)):
-            keep_center = self.center.clone()
-            self.shape += 2 * other
-            self.center = keep_center
-            return self
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            keep_center = self.center.clone()
-            self.shape += 2 * torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    def get_coordinate_corner_meshgrid(self):
+        """Returns a meshgrid with tangent plane coordinates for the corners
+        of every pixel.
+
+        """
+        pix = self.pixel_shape.to(dtype=AP_config.ap_dtype)
+        xsteps = (
+            torch.arange(
+                pix[0] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
-            self.center = keep_center
-            return self
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == (
-            2 * len(self.origin)
-        ):
-            self.origin -= self.cartesian_to_plane(
-                torch.as_tensor(
-                    other[::2], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-                )
+            - 0.5
+        )
+        ysteps = (
+            torch.arange(
+                pix[1] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
-            self.shape -= torch.as_tensor(
-                torch.sum(other.view(-1, 2), axis=0),
+            - 0.5
+        )
+        meshx, meshy = torch.meshgrid(
+            xsteps,
+            ysteps,
+            indexing="xy",
+        )
+        Coords = self.pixel_to_plane(meshx, meshy)
+        return torch.stack(Coords)
+
+    @torch.no_grad()
+    def get_coordinate_simps_meshgrid(self):
+        """Returns a meshgrid with tangent plane coordinates for performing
+        simpsons method pixel integration (all corners, centers, and
+        middle of each edge). This is approximately 4 times more
+        points than the standard :meth:`get_coordinate_meshgrid`.
+
+        """
+        pix = self.pixel_shape.to(dtype=AP_config.ap_dtype)
+        xsteps = (
+            0.5
+            * torch.arange(
+                2 * (pix[0]) + 1,
                 dtype=AP_config.ap_dtype,
                 device=AP_config.ap_device,
             )
-            return self
-        raise ValueError(f"Window object cannot be added with {type(other)}")
-
-    @torch.no_grad()
-    def __sub__(self, other):
-        """Reduce the size of the window. This operation preserves the window
-        center and changes the size (shape) of the window by reducing
-        the border.
-
-        """
-        if isinstance(other, (float, int, torch.dtype)):
-            new_shape = self.shape - 2 * other
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            new_shape = self.shape - 2 * torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        raise ValueError(f"Window object cannot be added with {type(other)}")
-
-    @torch.no_grad()
-    def __isub__(self, other):
-        if isinstance(other, (float, int, torch.dtype)) or (
-            isinstance(other, torch.Tensor) and other.numel() == 1
-        ):
-            keep_center = self.center.clone()
-            self.shape -= 2 * other
-            self.center = keep_center
-            return self
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            keep_center = self.center.clone()
-            self.shape -= 2 * torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            self.center = keep_center
-            return self
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == (
-            2 * len(self.origin)
-        ):
-            self.origin += torch.as_tensor(
-                other[::2], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            self.shape -= torch.as_tensor(
-                torch.sum(other.view(-1, 2), axis=0),
+            - 0.5
+        )
+        ysteps = (
+            0.5
+            * torch.arange(
+                2 * (pix[1]) + 1,
                 dtype=AP_config.ap_dtype,
                 device=AP_config.ap_device,
             )
-            return self
-        raise ValueError(f"Window object cannot be added with {type(other)}")
+            - 0.5
+        )
+        meshx, meshy = torch.meshgrid(
+            xsteps,
+            ysteps,
+            indexing="xy",
+        )
+        Coords = self.pixel_to_plane(meshx, meshy)
+        return torch.stack(Coords)
 
-    @torch.no_grad()
-    def __mul__(self, other):
-        """Add to the size of the window. This operation preserves the window
-        center and changes the size (shape) of the window by
-        multiplying the border.
+    # # Window adjustment operators
+    # @torch.no_grad()
+    # def __add__(self, other):
+    #     """Add to the size of the window. This operation preserves the window
+    #     center and changes the size (shape) of the window by
+    #     increasing the border.
 
-        """
-        if isinstance(other, (float, int, torch.dtype)):
-            new_shape = self.shape * other
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            new_shape = self.shape * torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        raise ValueError(f"Window object cannot be added with {type(other)}")
+    #     """
+    #     if isinstance(other, (float, int, torch.dtype)):
+    #         new_shape = self.shape + 2 * other
+    #         return self.copy(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixel_shape=None,
+    #         )
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         new_shape = self.shape + 2 * torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         return self.copy(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixel_shape=None,
+    #         )
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
 
-    @torch.no_grad()
-    def __imul__(self, other):
-        if isinstance(other, (float, int, torch.dtype)):
-            keep_center = self.center.clone()
-            self.shape *= other
-            self.center = keep_center
-            return self
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            keep_center = self.center.clone()
-            self.shape *= torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            self.center = keep_center
-            return self
-        raise ValueError(f"Window object cannot be added with {type(other)}")
+    # @torch.no_grad()
+    # def __iadd__(self, other):
+    #     if isinstance(other, (float, int, torch.dtype)):
+    #         keep_center = self.center.clone()
+    #         self.shape += 2 * other
+    #         self.center = keep_center
+    #         return self
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         keep_center = self.center.clone()
+    #         self.shape += 2 * torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         self.center = keep_center
+    #         return self
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == (
+    #         2 * len(self.origin)
+    #     ):
+    #         self.origin -= self.cartesian_to_plane(
+    #             torch.as_tensor(
+    #                 other[::2], dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #             )
+    #         )
+    #         self.shape -= torch.as_tensor(
+    #             torch.sum(other.view(-1, 2), axis=0),
+    #             dtype=AP_config.ap_dtype,
+    #             device=AP_config.ap_device,
+    #         )
+    #         return self
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
 
-    @torch.no_grad()
-    def __truediv__(self, other):
-        """Reduce the size of the window. This operation preserves the window
-        center and changes the size (shape) of the window by
-        dividing the border.
+    # @torch.no_grad()
+    # def __sub__(self, other):
+    #     """Reduce the size of the window. This operation preserves the window
+    #     center and changes the size (shape) of the window by reducing
+    #     the border.
 
-        """
-        if isinstance(other, (float, int, torch.dtype)):
-            new_shape = self.shape / other
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            new_shape = self.shape / torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            return self.__class__(
-                center=self.center,
-                shape=new_shape,
-                pixelshape=self.pixelshape,
-                projection=self.projection,
-                reference_radec=self.reference_radec,
-            )
-        raise ValueError(f"Window object cannot be added with {type(other)}")
+    #     """
+    #     if isinstance(other, (float, int, torch.dtype)):
+    #         new_shape = self.shape - 2 * other
+    #         return self.__class__(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixelshape=self.pixelshape,
+    #             projection=self.projection,
+    #             reference_radec=self.reference_radec,
+    #         )
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         new_shape = self.shape - 2 * torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         return self.__class__(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixelshape=self.pixelshape,
+    #             projection=self.projection,
+    #             reference_radec=self.reference_radec,
+    #         )
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
 
-    @torch.no_grad()
-    def __itruediv__(self, other):
-        if isinstance(other, (float, int, torch.dtype)):
-            keep_center = self.center.clone()
-            self.shape /= other
-            self.center = keep_center
-            return self
-        elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
-            self.origin
-        ):
-            keep_center = self.center.clone()
-            self.shape /= torch.as_tensor(
-                other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            self.center = keep_center
-            return self
-        raise ValueError(f"Window object cannot be added with {type(other)}")
+    # @torch.no_grad()
+    # def __isub__(self, other):
+    #     if isinstance(other, (float, int, torch.dtype)) or (
+    #         isinstance(other, torch.Tensor) and other.numel() == 1
+    #     ):
+    #         keep_center = self.center.clone()
+    #         self.shape -= 2 * other
+    #         self.center = keep_center
+    #         return self
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         keep_center = self.center.clone()
+    #         self.shape -= 2 * torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         self.center = keep_center
+    #         return self
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == (
+    #         2 * len(self.origin)
+    #     ):
+    #         self.origin += torch.as_tensor(
+    #             other[::2], dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         self.shape -= torch.as_tensor(
+    #             torch.sum(other.view(-1, 2), axis=0),
+    #             dtype=AP_config.ap_dtype,
+    #             device=AP_config.ap_device,
+    #         )
+    #         return self
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
+
+    # @torch.no_grad()
+    # def __mul__(self, other):
+    #     """Add to the size of the window. This operation preserves the window
+    #     center and changes the size (shape) of the window by
+    #     multiplying the border.
+
+    #     """
+    #     if isinstance(other, (float, int, torch.dtype)):
+    #         new_shape = self.shape * other
+    #         return self.__class__(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixelshape=self.pixelshape,
+    #             projection=self.projection,
+    #             reference_radec=self.reference_radec,
+    #         )
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         new_shape = self.shape * torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         return self.__class__(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixelshape=self.pixelshape,
+    #             projection=self.projection,
+    #             reference_radec=self.reference_radec,
+    #         )
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
+
+    # @torch.no_grad()
+    # def __imul__(self, other):
+    #     if isinstance(other, (float, int, torch.dtype)):
+    #         keep_center = self.center.clone()
+    #         self.shape *= other
+    #         self.center = keep_center
+    #         return self
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         keep_center = self.center.clone()
+    #         self.shape *= torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         self.center = keep_center
+    #         return self
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
+
+    # @torch.no_grad()
+    # def __truediv__(self, other):
+    #     """Reduce the size of the window. This operation preserves the window
+    #     center and changes the size (shape) of the window by
+    #     dividing the border.
+
+    #     """
+    #     if isinstance(other, (float, int, torch.dtype)):
+    #         new_shape = self.shape / other
+    #         return self.__class__(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixelshape=self.pixelshape,
+    #             projection=self.projection,
+    #             reference_radec=self.reference_radec,
+    #         )
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         new_shape = self.shape / torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         return self.__class__(
+    #             center=self.center,
+    #             shape=new_shape,
+    #             pixelshape=self.pixelshape,
+    #             projection=self.projection,
+    #             reference_radec=self.reference_radec,
+    #         )
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
+
+    # @torch.no_grad()
+    # def __itruediv__(self, other):
+    #     if isinstance(other, (float, int, torch.dtype)):
+    #         keep_center = self.center.clone()
+    #         self.shape /= other
+    #         self.center = keep_center
+    #         return self
+    #     elif isinstance(other, (tuple, torch.Tensor)) and len(other) == len(
+    #         self.origin
+    #     ):
+    #         keep_center = self.center.clone()
+    #         self.shape /= torch.as_tensor(
+    #             other, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+    #         )
+    #         self.center = keep_center
+    #         return self
+    #     raise ValueError(f"Window object cannot be added with {type(other)}")
 
     # Window Comparison operators
     @torch.no_grad()
     def __eq__(self, other):
-        return torch.all(self.origin == other.origin) and torch.all(
-            self.shape == other.shape
-        )
+        return torch.all(
+            self.pixel_shape == other.pixel_shape
+        ) and torch.all(
+            self.pixelscale == other.pixelscale
+        ) and (
+            self.projection == other.projection
+        ) and (
+            torch.all(self.pixel_to_plane(torch.zeros_like(self.reference_imageij)) == other.pixel_to_plane(torch.zeros_like(other.reference_imageij)))
+        ) # fixme more checks?
+    
 
     @torch.no_grad()
     def __ne__(self, other):
         return not self == other
 
-    @torch.no_grad()
-    def __gt__(self, other):
-        return torch.all(self.origin < other.origin) and torch.all(
-            (self.origin + self.shape) > (other.origin + other.shape)
-        )
-
-    @torch.no_grad()
-    def __ge__(self, other):
-        return torch.all(self.origin <= other.origin) and torch.all(
-            (self.origin + self.shape) >= (other.origin + other.shape)
-        )
-
-    @torch.no_grad()
-    def __lt__(self, other):
-        return torch.all(self.origin > other.origin) and torch.all(
-            (self.origin + self.shape) < (other.origin + other.shape)
-        )
-
-    @torch.no_grad()
-    def __le__(self, other):
-        return torch.all(self.origin >= other.origin) and torch.all(
-            (self.origin + self.shape) <= (other.origin + other.shape)
-        )
-
     # Window interaction operators
     @torch.no_grad()
     def __or__(self, other):
-        cart_self_origin = self.plane_to_cartesian(self.origin)
-        cart_other_origin = self.plane_to_cartesian(other.origin)
+        other_origin_pix = self.plane_to_pixel(other.origin)
+        new_origin_pix = torch.minimum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
-        new_origin = torch.minimum(cart_self_origin, cart_other_origin)
-        new_end = torch.maximum(
-            cart_self_origin + self.shape, cart_other_origin + other.shape
-        )
-        return self.__class__(
-            origin=self.cartesian_to_plane(new_origin),
-            shape=new_end - new_origin,
-            pixelshape=self.pixelshape,
-            projection=self.projection,
-            reference_radec=self.reference_radec,
+        other_pixel_end = self.plane_to_pixel(other.origin + other.end)
+        new_pixel_end = torch.maximum(self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end)
+        return self.copy(
+            origin=self.pixel_to_plane(new_origin_pix),
+            pixel_shape=new_pixel_end - new_origin_pix,
         )
 
     @torch.no_grad()
     def __ior__(self, other):
-        cart_self_origin = self.plane_to_cartesian(self.origin)
-        cart_other_origin = self.plane_to_cartesian(other.origin)
+        other_origin_pix = self.plane_to_pixel(other.origin)
+        new_origin_pix = torch.minimum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
-        new_origin = torch.minimum(cart_self_origin, cart_other_origin)
-        new_end = torch.maximum(
-            cart_self_origin + self.shape, cart_other_origin + other.shape
-        )
-        self.origin = self.cartesian_to_plane(new_origin)
-        self.shape = new_end - new_origin
+        other_pixel_end = self.plane_to_pixel(other.origin + other.end)
+        new_pixel_end = torch.maximum(self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end)
+
+        self.reference_imageij = self.reference_imageij - (new_origin_pix + 0.5)
+        self.pixel_shape = new_pixel_end - new_origin_pix
         return self
 
     @torch.no_grad()
     def __and__(self, other):
-        cart_self_origin = self.plane_to_cartesian(self.origin)
-        cart_other_origin = self.plane_to_cartesian(other.origin)
+        other_origin_pix = self.plane_to_pixel(other.origin)
+        new_origin_pix = torch.maximum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
-        new_origin = torch.maximum(cart_self_origin, cart_other_origin)
-        new_end = torch.minimum(
-            cart_self_origin + self.shape, cart_other_origin + other.shape
-        )
-        return self.__class__(
-            origin=self.cartesian_to_plane(new_origin),
-            shape=new_end - new_origin,  # fixme might not be right
-            pixelshape=self.pixelshape,
-            projection=self.projection,
-            reference_radec=self.reference_radec,
+        other_pixel_end = self.plane_to_pixel(other.origin + other.end)
+        new_pixel_end = torch.minimum(self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end)
+        return self.copy(
+            origin=self.pixel_to_plane(new_origin_pix),
+            pixel_shape=new_pixel_end - new_origin_pix,
         )
 
     @torch.no_grad()
     def __iand__(self, other):
-        cart_self_origin = self.plane_to_cartesian(self.origin)
-        cart_other_origin = self.plane_to_cartesian(other.origin)
+        other_origin_pix = self.plane_to_pixel(other.origin)
+        new_origin_pix = torch.maximum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
-        new_origin = torch.maximum(cart_self_origin, cart_other_origin)
-        new_end = torch.minimum(
-            cart_self_origin + self.shape, cart_other_origin + other.shape
-        )
-        self.origin = self.cartesian_to_plane(new_origin)
-        self.shape = new_end - new_origin
+        other_pixel_end = self.plane_to_pixel(other.origin + other.end)
+        new_pixel_end = torch.minimum(self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end)
+
+        self.reference_imageij = self.reference_imageij - (new_origin_pix + 0.5)
+        self.pixel_shape = new_pixel_end - new_origin_pix
         return self
 
     def __str__(self):
-        return f"window origin: {self.origin.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}, center: {self.center.detach().cpu().tolist()}, pixelshape: {self.pixelshape.detach().tolist()}"
+        return f"window origin: {self.origin.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}, center: {self.center.detach().cpu().tolist()}, pixelscale: {self.pixelscale.detach().tolist()}"
 
     def __repr__(self):
-        return f"window origin: {self.origin.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}, center: {self.center.detach().cpu().tolist()}, pixelshape: {self.pixelshape.detach().tolist()}"
+        return f"window pixel_shape: {self.pixel_shape.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}\n" + super().__repr__()
 
 
 class Window_List(Window):
     def __init__(self, window_list=None, state=None):
         if state is not None:
-            self.update_state(state)
+            self.set_state(state)
         else:
             assert (
                 window_list is not None
@@ -579,7 +749,11 @@ class Window_List(Window):
         """
         ref = torch.stack(tuple(W.reference_radec for W in self.window_list))
         if not torch.allclose(ref, ref[0]):
-            AP_config.error("Reference coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.error("Reference (world) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+
+        ref = torch.stack(tuple(W.reference_planexy for W in self.window_list))
+        if not torch.allclose(ref, ref[0]):
+            AP_config.error("Reference (tangent plane) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
         if len(set(W.projection for W in self.window_list)) > 1:
             AP_config.error("Projection missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
@@ -612,7 +786,7 @@ class Window_List(Window):
     def get_state(self):
         return list(window.get_state() for window in self)
 
-    def update_state(self, state):
+    def set_state(self, state):
         self.window_list = list(Window(state=st) for st in state)
 
     # Window interaction operators
@@ -648,98 +822,98 @@ class Window_List(Window):
     def __ne__(self, other):
         return not self == other
 
-    @torch.no_grad()
-    def __gt__(self, other):
-        results = list((sw > ow).view(-1) for sw, ow in zip(self, other))
-        return torch.all(torch.cat(results))
+    # @torch.no_grad()
+    # def __gt__(self, other):
+    #     results = list((sw > ow).view(-1) for sw, ow in zip(self, other))
+    #     return torch.all(torch.cat(results))
 
-    @torch.no_grad()
-    def __ge__(self, other):
-        results = list((sw >= ow).view(-1) for sw, ow in zip(self, other))
-        return torch.all(torch.cat(results))
+    # @torch.no_grad()
+    # def __ge__(self, other):
+    #     results = list((sw >= ow).view(-1) for sw, ow in zip(self, other))
+    #     return torch.all(torch.cat(results))
 
-    @torch.no_grad()
-    def __lt__(self, other):
-        results = list((sw < ow).view(-1) for sw, ow in zip(self, other))
-        return torch.all(torch.cat(results))
+    # @torch.no_grad()
+    # def __lt__(self, other):
+    #     results = list((sw < ow).view(-1) for sw, ow in zip(self, other))
+    #     return torch.all(torch.cat(results))
 
-    @torch.no_grad()
-    def __le__(self, other):
-        results = list((sw <= ow).view(-1) for sw, ow in zip(self, other))
-        return torch.all(torch.cat(results))
+    # @torch.no_grad()
+    # def __le__(self, other):
+    #     results = list((sw <= ow).view(-1) for sw, ow in zip(self, other))
+    #     return torch.all(torch.cat(results))
 
-    # Window adjustment operators
-    @torch.no_grad()
-    def __add__(self, other):
-        try:
-            new_windows = list(sw + ow for sw, ow in zip(self, other))
-        except TypeError:
-            new_windows = list(sw + other for sw in self)
-        return self.__class__(window_list=new_windows)
+    # # Window adjustment operators
+    # @torch.no_grad()
+    # def __add__(self, other):
+    #     try:
+    #         new_windows = list(sw + ow for sw, ow in zip(self, other))
+    #     except TypeError:
+    #         new_windows = list(sw + other for sw in self)
+    #     return self.__class__(window_list=new_windows)
 
-    @torch.no_grad()
-    def __sub__(self, other):
-        try:
-            new_windows = list(sw - ow for sw, ow in zip(self, other))
-        except TypeError:
-            new_windows = list(sw - other for sw in self)
-        return self.__class__(window_list=new_windows)
+    # @torch.no_grad()
+    # def __sub__(self, other):
+    #     try:
+    #         new_windows = list(sw - ow for sw, ow in zip(self, other))
+    #     except TypeError:
+    #         new_windows = list(sw - other for sw in self)
+    #     return self.__class__(window_list=new_windows)
 
-    @torch.no_grad()
-    def __mul__(self, other):
-        try:
-            new_windows = list(sw * ow for sw, ow in zip(self, other))
-        except TypeError:
-            new_windows = list(sw * other for sw in self)
-        return self.__class__(window_list=new_windows)
+    # @torch.no_grad()
+    # def __mul__(self, other):
+    #     try:
+    #         new_windows = list(sw * ow for sw, ow in zip(self, other))
+    #     except TypeError:
+    #         new_windows = list(sw * other for sw in self)
+    #     return self.__class__(window_list=new_windows)
 
-    @torch.no_grad()
-    def __truediv__(self, other):
-        try:
-            new_windows = list(sw / ow for sw, ow in zip(self, other))
-        except TypeError:
-            new_windows = list(sw / other for sw in self)
-        return self.__class__(window_list=new_windows)
+    # @torch.no_grad()
+    # def __truediv__(self, other):
+    #     try:
+    #         new_windows = list(sw / ow for sw, ow in zip(self, other))
+    #     except TypeError:
+    #         new_windows = list(sw / other for sw in self)
+    #     return self.__class__(window_list=new_windows)
 
-    @torch.no_grad()
-    def __iadd__(self, other):
-        try:
-            for sw, ow in zip(self, other):
-                sw += ow
-        except TypeError:
-            for sw in self:
-                sw += other
-        return self
+    # @torch.no_grad()
+    # def __iadd__(self, other):
+    #     try:
+    #         for sw, ow in zip(self, other):
+    #             sw += ow
+    #     except TypeError:
+    #         for sw in self:
+    #             sw += other
+    #     return self
 
-    @torch.no_grad()
-    def __isub__(self, other):
-        try:
-            for sw, ow in zip(self, other):
-                sw -= ow
-        except TypeError:
-            for sw in self:
-                sw -= other
-        return self
+    # @torch.no_grad()
+    # def __isub__(self, other):
+    #     try:
+    #         for sw, ow in zip(self, other):
+    #             sw -= ow
+    #     except TypeError:
+    #         for sw in self:
+    #             sw -= other
+    #     return self
 
-    @torch.no_grad()
-    def __imul__(self, other):
-        try:
-            for sw, ow in zip(self, other):
-                sw *= ow
-        except TypeError:
-            for sw in self:
-                sw *= other
-        return self
+    # @torch.no_grad()
+    # def __imul__(self, other):
+    #     try:
+    #         for sw, ow in zip(self, other):
+    #             sw *= ow
+    #     except TypeError:
+    #         for sw in self:
+    #             sw *= other
+    #     return self
 
-    @torch.no_grad()
-    def __itruediv__(self, other):
-        try:
-            for sw, ow in zip(self, other):
-                sw /= ow
-        except TypeError:
-            for sw in self:
-                sw /= other
-        return self
+    # @torch.no_grad()
+    # def __itruediv__(self, other):
+    #     try:
+    #         for sw, ow in zip(self, other):
+    #             sw /= ow
+    #     except TypeError:
+    #         for sw in self:
+    #             sw /= other
+    #     return self
 
     def __len__(self):
         return len(self.window_list)

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -100,7 +100,7 @@ class Window(WCS):
             return
         
         # Collect the shape of the window
-        if pixel_shape is None:
+        if pixel_shape is not None:
             self.pixel_shape = pixel_shape
         else:
             self.pixel_shape = wcs.pixel_shape

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -58,9 +58,27 @@ class Window(WCS):
           DEC in degrees), as a 1D array of length 2. Default is None.
       wcs: An astropy.wcs.WCS object which gives information about the
           origin and orientation of the window.
-      reference_radec: Coordinates in the celestial sphere (RA DEC) where
-          the world coordinate system meets the tangent plane where most
-          AstroPhot calculations are performed.
+      reference_radec: world coordinates on the celestial sphere (RA,
+          DEC in degrees) where the tangent plane makes contact. This should
+          be the same for every image in multi-image analysis.
+      reference_planexy: tangent plane coordinates (arcsec) where it
+          makes contact with the celesial sphere. This should typically be
+          (0,0) though that is not stricktly enforced (it is assumed if not
+          given). This reference coordinate should be the same for all
+          images in multi-image analysis.
+      reference_imageij: pixel coordinates about which the image is
+          defined. For example in an Astropy WCS object the wcs.wcs.crpix
+          array gives the pixel coordinate reference point for which the
+          world coordinate mapping (wcs.wcs.crval) is defined. One may think
+          of the referenced pixel location as being "pinned" to the tangent
+          plane. This may be different for each image in multi-image
+          analysis..
+      reference_imagexy: tangent plane coordinates (arcsec) about
+          which the image is defined. This is the pivot point about which the
+          pixelscale matrix operates, therefore if the pixelscale matrix
+          defines a rotation then this is the coordinate about which the
+          rotation will be performed. This may be different for each image in
+          multi-image analysis.
 
     """
 

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -71,13 +71,13 @@ class Window(WCS):
                 origin_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
             super().__init__(reference_radec=origin_radec)
-            self.origin = self.world_to_plane(*origin_radec)
+            self.origin = torch.stack(self.world_to_plane(*origin_radec))
         elif center_radec is not None:
             center_radec = torch.as_tensor(
                 center_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
             super().__init__(reference_radec=center_radec)
-            self.center = self.world_to_plane(*center_radec)
+            self.center = torch.stack(self.world_to_plane(*center_radec))
         elif origin is not None:
             self.origin = torch.as_tensor(
                 origin, dtype=AP_config.ap_dtype, device=AP_config.ap_device
@@ -94,7 +94,7 @@ class Window(WCS):
                 device=AP_config.ap_device,
             )
             super().__init__(reference_radec=wcs_origin)
-            self.origin = self.world_to_plane(*wcs_origin)
+            self.origin = torch.stack(self.world_to_plane(*wcs_origin))
         else:
             raise ValueError(
                 "One of center or origin must be provided to create window"
@@ -115,13 +115,13 @@ class Window(WCS):
             - self.end / 2
         )
 
-    def plane_to_cartesian(self, world_coordinate):
+    def plane_to_cartesian(self, plane_coordinate):
         """Projects a tangent plane coordinate which may be rotated, flipped, or
         sheered into a regular square cartesian grid for the purpose
         of comparisons and where arithmetic is more straightforward.
 
         """
-        return torch.linalg.solve(self.pixelshape, world_coordinate)
+        return torch.linalg.solve(self.pixelshape, plane_coordinate)
 
     def cartesian_to_plane(self, cartesian_coordinate):
         return self.pixelshape @ cartesian_coordinate

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -525,21 +525,21 @@ class Window_List(Window):
         self.check_wcs()
         
     def check_wcs(self):
-        """Ensure the WCS system being used by all the windows in this list
+        """Ensure the WCS systems being used by all the windows in this list
         are consistent with each other. They should all project world
         coordinates onto the same tangent plane.
 
         """
         ref = torch.stack(tuple(W.reference_radec for W in filter(lambda w: w is not None, self.window_list)))
         if not torch.allclose(ref, ref[0]):
-            AP_config.ap_logger.error("Reference (world) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference (world) coordinate mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
         ref = torch.stack(tuple(W.reference_planexy for W in filter(lambda w: w is not None, self.window_list)))
         if not torch.allclose(ref, ref[0]):
-            AP_config.ap_logger.error("Reference (tangent plane) coordinate missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Reference (tangent plane) coordinate mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
 
         if len(set(W.projection for W in filter(lambda w: w is not None, self.window_list))) > 1:
-            AP_config.ap_logger.error("Projection missmatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            AP_config.ap_logger.error("Projection mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
             
             
     @property
@@ -609,99 +609,6 @@ class Window_List(Window):
     @torch.no_grad()
     def __ne__(self, other):
         return not self == other
-
-    # @torch.no_grad()
-    # def __gt__(self, other):
-    #     results = list((sw > ow).view(-1) for sw, ow in zip(self, other))
-    #     return torch.all(torch.cat(results))
-
-    # @torch.no_grad()
-    # def __ge__(self, other):
-    #     results = list((sw >= ow).view(-1) for sw, ow in zip(self, other))
-    #     return torch.all(torch.cat(results))
-
-    # @torch.no_grad()
-    # def __lt__(self, other):
-    #     results = list((sw < ow).view(-1) for sw, ow in zip(self, other))
-    #     return torch.all(torch.cat(results))
-
-    # @torch.no_grad()
-    # def __le__(self, other):
-    #     results = list((sw <= ow).view(-1) for sw, ow in zip(self, other))
-    #     return torch.all(torch.cat(results))
-
-    # # Window adjustment operators
-    # @torch.no_grad()
-    # def __add__(self, other):
-    #     try:
-    #         new_windows = list(sw + ow for sw, ow in zip(self, other))
-    #     except TypeError:
-    #         new_windows = list(sw + other for sw in self)
-    #     return self.__class__(window_list=new_windows)
-
-    # @torch.no_grad()
-    # def __sub__(self, other):
-    #     try:
-    #         new_windows = list(sw - ow for sw, ow in zip(self, other))
-    #     except TypeError:
-    #         new_windows = list(sw - other for sw in self)
-    #     return self.__class__(window_list=new_windows)
-
-    # @torch.no_grad()
-    # def __mul__(self, other):
-    #     try:
-    #         new_windows = list(sw * ow for sw, ow in zip(self, other))
-    #     except TypeError:
-    #         new_windows = list(sw * other for sw in self)
-    #     return self.__class__(window_list=new_windows)
-
-    # @torch.no_grad()
-    # def __truediv__(self, other):
-    #     try:
-    #         new_windows = list(sw / ow for sw, ow in zip(self, other))
-    #     except TypeError:
-    #         new_windows = list(sw / other for sw in self)
-    #     return self.__class__(window_list=new_windows)
-
-    # @torch.no_grad()
-    # def __iadd__(self, other):
-    #     try:
-    #         for sw, ow in zip(self, other):
-    #             sw += ow
-    #     except TypeError:
-    #         for sw in self:
-    #             sw += other
-    #     return self
-
-    # @torch.no_grad()
-    # def __isub__(self, other):
-    #     try:
-    #         for sw, ow in zip(self, other):
-    #             sw -= ow
-    #     except TypeError:
-    #         for sw in self:
-    #             sw -= other
-    #     return self
-
-    # @torch.no_grad()
-    # def __imul__(self, other):
-    #     try:
-    #         for sw, ow in zip(self, other):
-    #             sw *= ow
-    #     except TypeError:
-    #         for sw in self:
-    #             sw *= other
-    #     return self
-
-    # @torch.no_grad()
-    # def __itruediv__(self, other):
-    #     try:
-    #         for sw, ow in zip(self, other):
-    #             sw /= ow
-    #     except TypeError:
-    #         for sw in self:
-    #             sw /= other
-    #     return self
 
     def __len__(self):
         return len(self.window_list)

--- a/astrophot/models/_shared_methods.py
+++ b/astrophot/models/_shared_methods.py
@@ -104,7 +104,7 @@ def parametric_initialize(
     edge_average = np.median(edge)
     edge_scatter = iqr(edge, rng=(16, 84)) / 2
     # Convert center coordinates to target area array indices
-    icenter = target_area.world_to_pixel(parameters["center"].value)
+    icenter = target_area.plane_to_pixel(parameters["center"].value)
 
     # Collect isophotes for 1D fit
     iso_info = isophotes(
@@ -192,7 +192,7 @@ def parametric_segment_initialize(
     edge_average = np.median(edge)
     edge_scatter = iqr(edge, rng=(16, 84)) / 2
     # Convert center coordinates to target area array indices
-    icenter = target_area.world_to_pixel(model["center"].value)
+    icenter = target_area.plane_to_pixel(model["center"].value)
 
     iso_info = isophotes(
         target_area.data.detach().cpu().numpy() - edge_average,
@@ -566,7 +566,7 @@ def relspline_initialize(self, target=None, parameters=None, **kwargs):
 
     target_area = target[self.window]
     if parameters["I0"].value is None:
-        center = target_area.world_to_pixel(parameters["center"].value)
+        center = target_area.plane_to_pixel(parameters["center"].value)
         flux = target_area.data[center[1].int().item(), center[0].int().item()]
         parameters["I0"].set_value(torch.log10(torch.abs(flux) / target_area.pixel_area), override_locked = True)
         parameters["I0"].set_uncertainty(0.01, override_locked = True)

--- a/astrophot/models/airy_psf.py
+++ b/astrophot/models/airy_psf.py
@@ -57,7 +57,7 @@ class Airy_Star(Star_Model):
         ):
             return
         target_area = target[self.window]
-        icenter = target_area.world_to_pixel(parameters["center"].value)
+        icenter = target_area.plane_to_pixel(parameters["center"].value)
 
         if parameters["I0"].value is None:
             parameters["I0"].set_value(

--- a/astrophot/models/core_model.py
+++ b/astrophot/models/core_model.py
@@ -303,22 +303,6 @@ class AstroPhot_Model(object):
             self._window = window
         elif len(window) == 2:
             self._window = self.target.window.copy().crop_to_pixel(window)
-        # elif len(window) == 4:
-        #     origin = torch.tensor(
-        #         (window[0], window[1]),
-        #         dtype=AP_config.ap_dtype,
-        #         device=AP_config.ap_device,
-        #     )
-        #     end = torch.tensor(
-        #         (window[2], window[3]),
-        #         dtype=AP_config.ap_dtype,
-        #         device=AP_config.ap_device,
-        #     )
-        #     self._window = Window(
-        #         origin=origin,
-        #         shape=self.target.window.plane_to_cartesian(end - origin),
-        #         pixelshape=self.target.window.pixelshape,
-        #     )
         else:
             raise ValueError(f"Unrecognized window format: {str(window)}")
 

--- a/astrophot/models/core_model.py
+++ b/astrophot/models/core_model.py
@@ -319,7 +319,7 @@ class AstroPhot_Model(object):
                         )
                     )
                 ),
-                projection=self.target.pixelscale,
+                pixelshape=self.target.pixelscale,
             )
         elif len(window) == 4:
             origin = torch.tensor(
@@ -335,7 +335,7 @@ class AstroPhot_Model(object):
             self._window = Window(
                 origin=origin,
                 shape=self.target.window.plane_to_cartesian(end - origin),
-                projection=self.target.window.projection,
+                pixelshape=self.target.window.pixelshape,
             )
         else:
             raise ValueError(f"Unrecognized window format: {str(window)}")

--- a/astrophot/models/core_model.py
+++ b/astrophot/models/core_model.py
@@ -303,15 +303,15 @@ class AstroPhot_Model(object):
             self._window = window
         elif len(window) == 2:
             self._window = Window(
-                origin=self.target.pixel_to_world(
+                origin=self.target.pixel_to_plane(
                     torch.tensor(
                         (window[0][0] - 0.5, window[1][0] - 0.5),
                         dtype=AP_config.ap_dtype,
                         device=AP_config.ap_device,
                     )
                 ),
-                shape=self.target.window.world_to_cartesian(
-                    self.target.pixel_to_world_delta(
+                shape=self.target.window.plane_to_cartesian(
+                    self.target.pixel_to_plane_delta(
                         torch.tensor(
                             (window[0][1] - window[0][0], window[1][1] - window[1][0]),
                             dtype=AP_config.ap_dtype,
@@ -334,7 +334,7 @@ class AstroPhot_Model(object):
             )
             self._window = Window(
                 origin=origin,
-                shape=self.target.window.world_to_cartesian(end - origin),
+                shape=self.target.window.plane_to_cartesian(end - origin),
                 projection=self.target.window.projection,
             )
         else:

--- a/astrophot/models/core_model.py
+++ b/astrophot/models/core_model.py
@@ -302,41 +302,23 @@ class AstroPhot_Model(object):
         if isinstance(window, Window):
             self._window = window
         elif len(window) == 2:
-            self._window = Window(
-                origin=self.target.pixel_to_plane(
-                    torch.tensor(
-                        (window[0][0] - 0.5, window[1][0] - 0.5),
-                        dtype=AP_config.ap_dtype,
-                        device=AP_config.ap_device,
-                    )
-                ),
-                shape=self.target.window.plane_to_cartesian(
-                    self.target.pixel_to_plane_delta(
-                        torch.tensor(
-                            (window[0][1] - window[0][0], window[1][1] - window[1][0]),
-                            dtype=AP_config.ap_dtype,
-                            device=AP_config.ap_device,
-                        )
-                    )
-                ),
-                pixelshape=self.target.pixelscale,
-            )
-        elif len(window) == 4:
-            origin = torch.tensor(
-                (window[0], window[1]),
-                dtype=AP_config.ap_dtype,
-                device=AP_config.ap_device,
-            )
-            end = torch.tensor(
-                (window[2], window[3]),
-                dtype=AP_config.ap_dtype,
-                device=AP_config.ap_device,
-            )
-            self._window = Window(
-                origin=origin,
-                shape=self.target.window.plane_to_cartesian(end - origin),
-                pixelshape=self.target.window.pixelshape,
-            )
+            self._window = self.target.window.copy().crop_to_pixel(window)
+        # elif len(window) == 4:
+        #     origin = torch.tensor(
+        #         (window[0], window[1]),
+        #         dtype=AP_config.ap_dtype,
+        #         device=AP_config.ap_device,
+        #     )
+        #     end = torch.tensor(
+        #         (window[2], window[3]),
+        #         dtype=AP_config.ap_dtype,
+        #         device=AP_config.ap_device,
+        #     )
+        #     self._window = Window(
+        #         origin=origin,
+        #         shape=self.target.window.plane_to_cartesian(end - origin),
+        #         pixelshape=self.target.window.pixelshape,
+        #     )
         else:
             raise ValueError(f"Unrecognized window format: {str(window)}")
 

--- a/astrophot/models/edgeon_model.py
+++ b/astrophot/models/edgeon_model.py
@@ -58,7 +58,7 @@ class Edgeon_Model(Component_Model):
         )
         edge_average = np.median(edge)
         edge_scatter = iqr(edge, rng=(16, 84)) / 2
-        icenter = target_area.world_to_pixel(parameters["center"].value)
+        icenter = target_area.plane_to_pixel(parameters["center"].value)
 
         iso_info = isophotes(
             target_area.data.detach().cpu().numpy() - edge_average,
@@ -137,7 +137,7 @@ class Edgeon_Sech(Edgeon_Model):
         ):
             return
         target_area = target[self.window]
-        icenter = target_area.world_to_pixel(parameters["center"].value)
+        icenter = target_area.plane_to_pixel(parameters["center"].value)
 
         if parameters["I0"].value is None:
             parameters["I0"].set_value(

--- a/astrophot/models/galaxy_model_object.py
+++ b/astrophot/models/galaxy_model_object.py
@@ -76,7 +76,7 @@ class Galaxy_Model(Component_Model):
         )
         edge_average = np.nanmedian(edge)
         edge_scatter = iqr(edge[np.isfinite(edge)], rng=(16, 84)) / 2
-        icenter = target_area.world_to_pixel(parameters["center"].value)
+        icenter = target_area.plane_to_pixel(parameters["center"].value)
 
         if parameters["PA"].value is None:
             iso_info = isophotes(

--- a/astrophot/models/model_object.py
+++ b/astrophot/models/model_object.py
@@ -212,7 +212,7 @@ class Component_Model(AstroPhot_Model):
             return
 
         # Convert center coordinates to target area array indices
-        init_icenter = target_area.world_to_pixel(parameters["center"].value)
+        init_icenter = target_area.plane_to_pixel(parameters["center"].value)
 
         # Compute center of mass in window
         COM = center_of_mass(
@@ -229,7 +229,7 @@ class Component_Model(AstroPhot_Model):
             return
         COM = (COM[1], COM[0])
         # Convert center of mass indices to coordinates
-        COM_center = target_area.pixel_to_world(
+        COM_center = target_area.pixel_to_plane(
             torch.tensor(COM, dtype=AP_config.ap_dtype, device=AP_config.ap_device)
         )
 
@@ -331,7 +331,7 @@ class Component_Model(AstroPhot_Model):
             )
             # Sub pixel shift to align the model with the center of a pixel
             if self.psf_subpixel_shift != "none":
-                pixel_center = working_image.world_to_pixel(parameters["center"].value)
+                pixel_center = working_image.plane_to_pixel(parameters["center"].value)
                 center_shift = pixel_center - torch.round(pixel_center)
                 working_image.header.pixel_shift_origin(center_shift)
             else:

--- a/astrophot/models/model_object.py
+++ b/astrophot/models/model_object.py
@@ -322,7 +322,7 @@ class Component_Model(AstroPhot_Model):
             else:
                 psf = self.psf
             # Add border for psf convolution edge effects, will be cropped out later
-            working_window += psf.psf_border
+            working_window.pad_pixel(psf.psf_border_int)
             # Determine the pixels scale at which to evalaute, this is smaller if the PSF is upscaled
             working_pixelscale = image.pixelscale / psf.psf_upscale
             # Make the image object to which the samples will be tracked
@@ -333,7 +333,7 @@ class Component_Model(AstroPhot_Model):
             if self.psf_subpixel_shift != "none":
                 pixel_center = working_image.plane_to_pixel(parameters["center"].value)
                 center_shift = pixel_center - torch.round(pixel_center)
-                working_image.header.pixel_shift_origin(center_shift)
+                working_image.header.pixel_shift(center_shift)
             else:
                 center_shift = None
 
@@ -358,7 +358,7 @@ class Component_Model(AstroPhot_Model):
 
             # Shift image back to align with original pixel grid
             if self.psf_subpixel_shift != "none":
-                working_image.header.pixel_shift_origin(-center_shift)
+                working_image.header.pixel_shift(-center_shift)
             # Add the sampled/integrated/convolved pixels to the requested image
             working_image = working_image.reduce(psf.psf_upscale).crop(
                 psf.psf_border_int

--- a/astrophot/models/psf_model.py
+++ b/astrophot/models/psf_model.py
@@ -77,9 +77,7 @@ class PSF_Star(Star_Model):
             X, Y = Coords - parameters["center"].value[..., None, None]
 
         # Convert coordinates into pixel locations in the psf image
-        pX, pY = self.psf_model.plane_to_pixel(
-            torch.stack((X, Y)).view(2, -1), unsqueeze_origin=True
-        )
+        pX, pY = self.psf_model.plane_to_pixel(X, Y)
         pX = pX.reshape(X.shape)
         pY = pY.reshape(Y.shape)
 

--- a/astrophot/models/psf_model.py
+++ b/astrophot/models/psf_model.py
@@ -77,7 +77,7 @@ class PSF_Star(Star_Model):
             X, Y = Coords - parameters["center"].value[..., None, None]
 
         # Convert coordinates into pixel locations in the psf image
-        pX, pY = self.psf_model.world_to_pixel(
+        pX, pY = self.psf_model.plane_to_pixel(
             torch.stack((X, Y)).view(2, -1), unsqueeze_origin=True
         )
         pX = pX.reshape(X.shape)

--- a/astrophot/models/psf_model.py
+++ b/astrophot/models/psf_model.py
@@ -49,7 +49,7 @@ class PSF_Star(Star_Model):
                 data=torch.clone(self.psf.data),
                 pixelscale=self.psf.pixelscale,
             )
-        self.psf_model.header.shift_origin(
+        self.psf_model.header.shift(
             self.psf_model.origin - self.psf_model.center
         )
 

--- a/astrophot/plots/image.py
+++ b/astrophot/plots/image.py
@@ -58,29 +58,37 @@ def target_image(fig, ax, target, window=None, **kwargs):
     vmin = sky - 5 * noise
     vmax = sky + 5 * noise
 
-    im = ax.pcolormesh(
-        X,
-        Y,
-        dat,
-        cmap="Greys",
-        norm=ImageNormalize(
-            stretch=HistEqStretch(
-                dat[np.logical_and(dat <= (sky + 3 * noise), np.isfinite(dat))]
+    if kwargs.get("linear", False):
+        im = ax.pcolormesh(
+            X,
+            Y,
+            dat,
+            cmap=cmap_grad,
+        )
+    else:
+        im = ax.pcolormesh(
+            X,
+            Y,
+            dat,
+            cmap="Greys",
+            norm=ImageNormalize(
+                stretch=HistEqStretch(
+                    dat[np.logical_and(dat <= (sky + 3 * noise), np.isfinite(dat))]
+                ),
+                clip=False,
+                vmax=sky + 3 * noise,
+                vmin=np.nanmin(dat),
             ),
-            clip=False,
-            vmax=sky + 3 * noise,
-            vmin=np.nanmin(dat),
-        ),
-    )
+        )
 
-    im = ax.pcolormesh(
-        X,
-        Y,
-        np.ma.masked_where(dat < (sky + 3 * noise), dat),
-        cmap=cmap_grad,
-        norm=matplotlib.colors.LogNorm(),
-        clim=[sky + 3 * noise, None],
-    )
+        im = ax.pcolormesh(
+            X,
+            Y,
+            np.ma.masked_where(dat < (sky + 3 * noise), dat),
+            cmap=cmap_grad,
+            norm=matplotlib.colors.LogNorm(),
+            clim=[sky + 3 * noise, None],
+        )
 
     ax.axis("equal")
 
@@ -346,11 +354,11 @@ def model_window(fig, ax, model, target=None, rectangle_linewidth=2, **kwargs):
 
             lowright = use_window.shape.clone()
             lowright[1] = 0.0
-            lowright = use_window.origin + use_window.cartesian_to_world(lowright)
+            lowright = use_window.origin + use_window.cartesian_to_plane(lowright)
             lowright = lowright.detach().cpu().numpy()
             upleft = use_window.shape.clone()
             upleft[0] = 0.0
-            upleft = use_window.origin + use_window.cartesian_to_world(upleft)
+            upleft = use_window.origin + use_window.cartesian_to_plane(upleft)
             upleft = upleft.detach().cpu().numpy()
             end = use_window.origin + use_window.end
             end = end.detach().cpu().numpy()
@@ -381,11 +389,11 @@ def model_window(fig, ax, model, target=None, rectangle_linewidth=2, **kwargs):
             use_window = model.window
         lowright = use_window.shape.clone()
         lowright[1] = 0.0
-        lowright = use_window.origin + use_window.cartesian_to_world(lowright)
+        lowright = use_window.origin + use_window.cartesian_to_plane(lowright)
         lowright = lowright.detach().cpu().numpy()
         upleft = use_window.shape.clone()
         upleft[0] = 0.0
-        upleft = use_window.origin + use_window.cartesian_to_world(upleft)
+        upleft = use_window.origin + use_window.cartesian_to_plane(upleft)
         upleft = upleft.detach().cpu().numpy()
         end = use_window.origin + use_window.end
         end = end.detach().cpu().numpy()

--- a/astrophot/plots/image.py
+++ b/astrophot/plots/image.py
@@ -9,6 +9,7 @@ from scipy.stats import iqr
 
 from ..models import Group_Model, Sky_Model
 from ..image import Image_List, Window_List
+from .. import AP_config
 from ..utils.conversions.units import flux_to_sb
 from .visuals import *
 
@@ -352,13 +353,13 @@ def model_window(fig, ax, model, target=None, rectangle_linewidth=2, **kwargs):
             else:
                 use_window = m.window
 
-            lowright = use_window.shape.clone()
+            lowright = use_window.pixel_shape.clone().to(dtype=AP_config.ap_dtype)
             lowright[1] = 0.0
-            lowright = use_window.origin + use_window.cartesian_to_plane(lowright)
+            lowright = use_window.origin + use_window.pixel_to_plane_delta(lowright)
             lowright = lowright.detach().cpu().numpy()
-            upleft = use_window.shape.clone()
+            upleft = use_window.pixel_shape.clone().to(dtype=AP_config.ap_dtype)
             upleft[0] = 0.0
-            upleft = use_window.origin + use_window.cartesian_to_plane(upleft)
+            upleft = use_window.origin + use_window.pixel_to_plane_delta(upleft)
             upleft = upleft.detach().cpu().numpy()
             end = use_window.origin + use_window.end
             end = end.detach().cpu().numpy()
@@ -387,13 +388,13 @@ def model_window(fig, ax, model, target=None, rectangle_linewidth=2, **kwargs):
             use_window = model.window.window_list[model.target.index(target)]
         else:
             use_window = model.window
-        lowright = use_window.shape.clone()
+        lowright = use_window.pixel_shape.clone().to(dtype=AP_config.ap_dtype)
         lowright[1] = 0.0
-        lowright = use_window.origin + use_window.cartesian_to_plane(lowright)
+        lowright = use_window.origin + use_window.pixel_to_plane_delta(lowright)
         lowright = lowright.detach().cpu().numpy()
-        upleft = use_window.shape.clone()
+        upleft = use_window.pixel_shape.clone().to(dtype=AP_config.ap_dtype)
         upleft[0] = 0.0
-        upleft = use_window.origin + use_window.cartesian_to_plane(upleft)
+        upleft = use_window.origin + use_window.pixel_to_plane_delta(upleft)
         upleft = upleft.detach().cpu().numpy()
         end = use_window.origin + use_window.end
         end = end.detach().cpu().numpy()

--- a/astrophot/utils/operations.py
+++ b/astrophot/utils/operations.py
@@ -226,7 +226,7 @@ def grid_integrate(
     subgridres = grid_integrate(
         subgridX,
         subgridY,
-        image_header.rescale(gridding),
+        image_header.rescale_pixel(1/gridding),
         eval_brightness,
         eval_parameters,
         dtype,

--- a/astrophot/utils/operations.py
+++ b/astrophot/utils/operations.py
@@ -226,7 +226,7 @@ def grid_integrate(
     subgridres = grid_integrate(
         subgridX,
         subgridY,
-        image_header.super_resolve(gridding),
+        image_header.rescale(gridding),
         eval_brightness,
         eval_parameters,
         dtype,

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -1,0 +1,159 @@
+===========
+Coordinates
+===========
+
+Coordinate systems in astronomy can be complicated, AstroPhot is no
+different. Here we explain how coordinate systems are handled to help
+you avoid possible pitfalls.
+
+Basics
+------
+
+There are three main coordinate systems to think about.
+
+#. ``world`` coordinates are the classic (RA, DEC) that many
+   astronomical sources are represented in. These should always be
+   used in degree units as far as AstroPhot is concerned.
+#. ``plane`` coordinates are the tangent plane on which AstroPhot
+   performs it's calculations. Working on a plane makes everything
+   linear and does not introduce a noticible effect for small enough
+   images. In the tangent plane everything should be represented in
+   arcsecond units.
+#. ``pixel`` coordinates are specific to each image, they start at
+   (0,0) in the center of the [0,0] indexed pixel. These are
+   effectively unitless, a step of 1 in pixel coordinates is the same
+   as changing an index by 1. Note however that in the pixel
+   coordinate system the values are represented by floating point
+   numbers and so (1.3,2.8) is a valid pixel coordinate that is just
+   partway between pixel centers.
+
+Tranformations exist in AstroPhot for converting ``world`` to/from
+``plane`` and for converting ``plane`` to/from ``pixel``. The best way
+to interface with these is to use the ``image.header.world_to_plane``
+for any AstroPhot image object (you may similarly swap ``world``,
+``plane``, and ``pixel``).
+
+One gotcha to keep in mind with regards to ``world_to_plane`` and
+``plane_to_world`` is that AstroPhot needs to know the reference
+(RA_0, DEC_0) where the tangent plane coordinate (0,0) meets with the
+celestial sphere world coordinate. You can set this by including
+``reference_radec = (RA_0, DEC_0)`` as an argument in the first image
+you create. Subsequent images will not modify the reference. If a
+reference is not given, then one will be assumed based on avaialble
+information when the first image is created.
+
+Projection Systems
+------------------
+
+AstroPhot currently implements three coordinate reference systems:
+Gnomonic, Orthographic, and Steriographic. The default projection is
+the Gnomonic, which represents the perspective of an observer at the
+center of a sphere projected onto a plane. For the exact
+implementation by AstroPhot see the `Wolfram MathWorld
+<https://mathworld.wolfram.com/GnomonicProjection.html>`_ page.
+
+On small scales the choice of projection doesn't matter. For very
+large images the effect may be detectable, though it is likely
+insignificant compared to other effects in an image. Just like the
+``reference_radec`` you should choose your projection system in the
+first image you construct by passing ``projection = 'gnomonic'`` as an
+argument. Just like with the reference coordinate, subsequent image
+creation cannot modify the projection.
+
+If you really want to change the projection after the first image has
+been created (warning, this may cause serious missalignments between
+images), you can force it to update with::
+
+  image.header.projection = 'steriographic'
+
+which would change the projection to steriographic. This change can be
+made with any image and it will affect all AstroPhot images
+simultaneously. They won't recompute thier position in the new
+projection system, they will just use new equations going
+forward. Hence the potential to seriously mess up your image alignmnt
+if this is done after some calculations have already been performed.
+
+Talking to the world
+--------------------
+
+If you have images with WCS information (likely Astropy WCS) then you
+will want to use this to map images onto the same tangent plane. That
+is mostly described in the basics section, however there are some more
+features you can take advantage of. When creating an image in
+AstroPhot, you need to tell it some basic properties so that the image
+knows how to place itself in the tangent plane. Using the WCS object
+you should be able to recover the coordinates of the image in (RA,
+DEC), for a 10 pixel by 10 pixel image you could accomplish this by
+doing something like::
+
+  center = wcs.pixel_to_world(5,5)
+  ra, dec = center.ra.deg, center.dec.deg
+
+meaning that you know the world position of the image. To have
+AstroPhot place the image at the right location in the tangent plane
+you can use the ``center_radec`` argument when constructing the image
+which would look something like::
+
+  image = ap.image.Target_Image(
+      data = data,
+      pixelscale = pixelscale,
+      center_radec = (ra, dec),
+  )
+
+If this is the first image being constructed then AstroPhot will set
+the reference RA, DEC to these center coordinates and future images
+will project onto that tangent plane.
+
+You may also have a catalogue of objects that you would like to
+project into the image. The easiest way to do this if you already have
+an image object is to call the ``world_to_plane`` functions
+manually. Say for example that you know the object position as an
+Astropy ``SkyCoord`` object, and you want to use this to set the
+center position of a sersic model. That would look like::
+
+  model = ap.models.AstroPhot_Model(
+      name = "knowloc",
+      model_type = "sersic galaxy model",
+      target = image,
+      parameters = {
+          "center": image.header.world_to_plane(obj_pos.ra.deg, obj_pos.dec.deg),
+      }
+  )
+
+Which will start the object at the correct position in the image given
+its world coordinates. As you can see, the ``center`` and in fact all
+parameters for AstroPhot models are defined in the tangent plane. This
+means that if you have optimized a model and you would like to present
+it's position in world coordinates that can be compared with other
+sources, you will need to do the opposite operation::
+
+  world_position = image.header.plane_to_world(*model["center"].value)
+
+Which should be the coordinates in RA and DEC, assuming that you
+initialized the image with a WCS or by other means ensured that the
+world coordinates being used are correct. If you never gave AstroPhot
+the infomration it needs, then it likely assumed a reference position
+of (0,0) in the world coordinate system and so probably doesn't
+represent your object.
+
+
+Why global projection parameters?
+---------------------------------
+
+Aren't global variables bad? Well, in this case they are the best way
+to minimize potential surprises with regards to coordinate
+systems. Transforming from the celestial sphere world coordinates to
+tangent plane coordiantes is not a perfect operation, however it is
+made infinitely worse if you are unwittingly projecting onto multiple
+different tangent plane coordinate systems (say when doing
+multi-band/multi-epoch analysis of multiple images). By forcing the
+projection parameters to be global variables, all images may be
+projected into the same tangent plane using world coordinates with
+minimal chance to make mistakes along the way.
+
+I would discourage trying to switch back and forth between two
+coordinate systems in the same analysis pipeline. For the sake of your
+sanity, and AstroPhot's you are better off splitting multiple image
+analysis tasks into separate scripts. If the images are far enough
+that they can't be on the same tangent plane, then they are probably
+relatively simple to separate anyway.

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -15,7 +15,7 @@ There are three main coordinate systems to think about.
    astronomical sources are represented in. These should always be
    used in degree units as far as AstroPhot is concerned.
 #. ``plane`` coordinates are the tangent plane on which AstroPhot
-   performs it's calculations. Working on a plane makes everything
+   performs its calculations. Working on a plane makes everything
    linear and does not introduce a noticible effect for small enough
    images. In the tangent plane everything should be represented in
    arcsecond units.
@@ -23,10 +23,14 @@ There are three main coordinate systems to think about.
    (0,0) in the center of the [0,0] indexed pixel. These are
    effectively unitless, a step of 1 in pixel coordinates is the same
    as changing an index by 1. Though image array indexing is flipped
-   so pixel coordinate (1,0) represents the center of the index [0,1]
-   pixel. Also, in the pixel coordinate system the values are
-   represented by floating point numbers and so (1.3,2.8) is a valid
-   pixel coordinate that is just partway between pixel centers.
+   so pixel coordinate (3,10) represents the center of the index
+   [10,3] pixel. It is a convention for most images that the first
+   axis indexes vertically and the second axis indexis horizontally,
+   if this is not the case for oyur images you can apply a transpose
+   before passing the data to AstroPhot. Also, in the pixel coordinate
+   system the values are represented by floating point numbers and so
+   (1.3,2.8) is a valid pixel coordinate that is just partway between
+   pixel centers.
 
 Tranformations exist in AstroPhot for converting ``world`` to/from
 ``plane`` and for converting ``plane`` to/from ``pixel``. The best way
@@ -40,8 +44,8 @@ One gotcha to keep in mind with regards to ``world_to_plane`` and
 sphere. You can set this by including ``reference_radec = (RA_0,
 DEC_0)`` as an argument in an image you create.  If a reference is not
 given, then one will be assumed based on avaialble information. Note
-that if you are doing multiband analysis you should ensure that the
-``reference_radec`` is same for all images!
+that if you are doing simultaneous multi-image analysis you should
+ensure that the ``reference_radec`` is same for all images!
 
 Projection Systems
 ------------------
@@ -76,15 +80,24 @@ already been performed.
 Talking to the world
 --------------------
 
-If you have images with WCS information (likely Astropy WCS) then you
-will want to use this to map images onto the same tangent plane. That
-is mostly described in the basics section, however there are some more
-features you can take advantage of. When creating an image in
-AstroPhot, you need to tell it some basic properties so that the image
-knows how to place itself in the tangent plane. Using the WCS object
-you should be able to recover the coordinates of the image in (RA,
-DEC), for an example wcs object you could accomplish this by
-doing something like::
+If you have images with WCS information then you will want to use this
+to map images onto the same tangent plane. Often this will take the
+form of information in a FITS file, which can easily be accessed using
+Astropy like::
+
+  from astropy.io import fits
+  from astropy.wcs import WCS
+  hdu = fits.open("myimage.fits")
+  data = hdu[0].data
+  wcs = WCS(hdu[0].header)
+
+That is somewhat described in the basics section, however there are
+some more features you can take advantage of. When creating an image
+in AstroPhot, you need to tell it some basic properties so that the
+image knows how to place itself in the tangent plane. Using the
+Astropy WCS object above you should be able to recover the coordinates
+of the image in (RA, DEC), for an example Astropy wcs object you could
+accomplish this by doing something like::
 
   ra, dec = wcs.wcs.crval
 
@@ -101,7 +114,7 @@ would look something like::
 
 AstroPhot will set the reference RA, DEC to these coordinates and also
 set the image in the correct position. A more explicit alternative is
-to just say what the reference coordiante should be. That would look
+to just say what the reference coordinate should be. That would look
 something like::
   
   image = ap.image.Target_Image(
@@ -144,16 +157,17 @@ Which will start the object at the correct position in the image given
 its world coordinates. As you can see, the ``center`` and in fact all
 parameters for AstroPhot models are defined in the tangent plane. This
 means that if you have optimized a model and you would like to present
-it's position in world coordinates that can be compared with other
+its position in world coordinates that can be compared with other
 sources, you will need to do the opposite operation::
 
   world_position = image.window.plane_to_world(model["center"].value)
 
-Which should be the coordinates in RA and DEC (degrees), assuming that
-you initialized the image with a WCS or by other means ensured that
-the world coordinates being used are correct. If you never gave
-AstroPhot the information it needs, then it likely assumed a reference
-position of (0,0) in the world coordinate system.
+That should assign ``world_position`` the coordinates in RA and DEC
+(degrees), assuming that you initialized the image with a WCS or by
+other means ensured that the world coordinates being used are
+correct. If you never gave AstroPhot the information it needs, then it
+likely assumed a reference position of (0,0) in the world coordinate
+system.
 
 Coordinate reference points
 ---------------------------
@@ -165,9 +179,9 @@ of two vectors: ``reference_radec`` and ``reference_planexy``. These
 variables are stored in all ``Image_Header`` objects and essentially
 pin down the mapping such that one coordinate will get mapped to the
 other. All other coordinates follow from the projection system assumed
-(i.e. Gnomonic). It is possible to specify these variables directly
+(i.e., Gnomonic). It is possible to specify these variables directly
 when constructing an image, or implicitly if you give some other
-relevant information (eg an Astropy WCS). AstroPhot Window objects
+relevant information (e.g., an Astropy WCS). AstroPhot Window objects
 also keep track of two more vectors: ``reference_imageij`` and
 ``reference_imagexy``. These variables control where an image is
 placed in the tangent plane and represent a fixed point between the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ This documentation is a work in progress, further updates will come.
 
     install.rst
     getting_started.rst
+    tutorials.rst
     contributing.rst
     citation.rst
     license.rst   
@@ -54,8 +55,8 @@ This documentation includes all functions available in the AstroPhot package. Fo
     :maxdepth: 1
 
     modules.rst
+    coordinates.rst
     configfile_interface.rst
-    tutorials.rst
     troubleshooting.rst
               
 |br|

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -4,19 +4,44 @@ Troubleshooting
 
 Here we list issues that other users have encountered, and how to solve them!
 
-**If you encounter a new issue please make an "Issue" on the GitHub so I can fix it!** `GitHub Issues <https://github.com/Autostronomy/AstroPhot/issues>`_
+**If you encounter a new issue please make an "Issue" on the GitHub so
+ I can fix it!** `GitHub Issues
+ <https://github.com/Autostronomy/AstroPhot/issues>`_
 
 Jupyter notebook kernel died
 ----------------------------
 
-If you repeatedly get a `Kernel Restarting` message on your jupyter notebook with something like::
+If you repeatedly get a `Kernel Restarting` message on your jupyter
+notebook with something like::
 
     The kernel for NOTEBOOK.ipynb appears to have died. It will restart automatically.
 
-Then the issue might be how `PyTorch` and Jupyter talk to each other. This is a known problem that can occur (for example `see here <https://stackoverflow.com/questions/56759112/how-to-fix-the-kernel-appears-to-have-died-it-will-restart-automatically-caus>`_). The solution that works for most people is to just re-install `PyTorch` and possible `torchvision` as well.
+Then the issue might be how `PyTorch` and Jupyter talk to each
+other. This is a known problem that can occur (for example `see here
+<https://stackoverflow.com/questions/56759112/how-to-fix-the-kernel-appears-to-have-died-it-will-restart-automatically-caus>`_). The
+solution that works for most people is to just re-install `PyTorch`
+and possible `torchvision` as well.
 
 
 My images look mirrored
 -----------------------
 
-If you load a target image into `AstroPhot` and then try to plot it using one of the built-in plotting routines, you may notice that the image is flipped horizontally. This is likely because you initialized the `Target_Image` object with a `WCS` from astropy. This is totally normal, it comes from the fact that `RA` is defined as positive to the east (left side of a typical image). Most astrophot plotting routines that may be affected by this have an argument to fix it, just set: `flipx = True` in the plotting function and you should be good to go! Otherwise you can do it manually in matplotlib with `ax.invert_xaxis()`.
+If you load a target image into `AstroPhot` and then try to plot it
+using one of the built-in plotting routines, you may notice that the
+image is flipped horizontally. This is likely because you initialized
+the `Target_Image` object with a `WCS` from astropy. This is totally
+normal, it comes from the fact that `RA` is defined as positive to the
+east (left side of a typical image). Most astrophot plotting routines
+that may be affected by this have an argument to fix it, just set:
+`flipx = True` in the plotting function and you should be good to go!
+Otherwise you can do it manually in matplotlib with
+`ax.invert_xaxis()`.
+
+My object/images aren't where they should be
+--------------------------------------------
+
+If you objects aren't where they should be in an image, or your images
+aren't aligning properly, its possible that your coordinate system is
+misspecified. Please read the :doc:`coordinates` documentation to get
+some clarity on how AstroPhot handles coordinates. If that doesn't
+work, contact me!

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -28,13 +28,17 @@ My images look mirrored
 
 If you load a target image into `AstroPhot` and then try to plot it
 using one of the built-in plotting routines, you may notice that the
-image is flipped horizontally. This is likely because you initialized
-the `Target_Image` object with a `WCS` from astropy. This is totally
-normal, it comes from the fact that `RA` is defined as positive to the
-east (left side of a typical image). Most astrophot plotting routines
-that may be affected by this have an argument to fix it, just set:
-`flipx = True` in the plotting function and you should be good to go!
-Otherwise you can do it manually in matplotlib with
+image is flipped horizontally. This is likely because your pixelscale
+matrix has negative values such as::
+
+  [[-1, 0]
+   [ 0, 1]]
+
+This is totally normal, it comes from the fact that `RA` is defined as
+positive to the east (left side of a typical image). Most astrophot
+plotting routines that may be affected by this have an argument to fix
+it, just set: `flipx = True` in the plotting function and you should
+be good to go!  Otherwise you can do it manually in matplotlib with
 `ax.invert_xaxis()`.
 
 My object/images aren't where they should be

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -12,7 +12,7 @@ class TestImage(unittest.TestCase):
     def test_image_creation(self):
         arr = torch.zeros((10, 15))
         base_image = image.Image(
-            arr, pixelscale=1.0, zeropoint=1.0, origin=torch.zeros(2), note="test image"
+            data = arr, pixelscale=1.0, zeropoint=1.0, origin=torch.zeros(2), note="test image"
         )
 
         self.assertEqual(base_image.pixel_length, 1.0, "image should track pixelscale")
@@ -21,7 +21,7 @@ class TestImage(unittest.TestCase):
         self.assertEqual(base_image.origin[1], 0, "image should track origin")
         self.assertEqual(base_image.note, "test image", "image should track note")
 
-        slicer = image.Window((3, 2), (4, 5))
+        slicer = image.Window(origin = (3, 2), shape = (4, 5))
         sliced_image = base_image[slicer]
         self.assertEqual(sliced_image.origin[0], 3, "image should track origin")
         self.assertEqual(sliced_image.origin[1], 2, "image should track origin")
@@ -32,7 +32,7 @@ class TestImage(unittest.TestCase):
             base_image.origin[1], 0, "subimage should not change image origin"
         )
 
-        second_base_image = image.Image(arr, pixelscale=1.0, note="test image")
+        second_base_image = image.Image(data = arr, pixelscale=1.0, note="test image")
         self.assertEqual(base_image.pixel_length, 1.0, "image should track pixelscale")
         self.assertIsNone(second_base_image.zeropoint, "image should track zeropoint")
         self.assertEqual(second_base_image.origin[0], 0, "image should track origin")
@@ -44,7 +44,7 @@ class TestImage(unittest.TestCase):
     def test_copy(self):
 
         new_image = image.Image(
-            torch.zeros((10, 15)),
+            data = torch.zeros((10, 15)),
             pixelscale=1.0,
             zeropoint=1.0,
             origin=torch.zeros(2) + 0.1,
@@ -105,7 +105,7 @@ class TestImage(unittest.TestCase):
             origin=torch.ones(2),
             note="test image",
         )
-        slicer = image.Window((0, 0), (5, 5))
+        slicer = image.Window(origin = (0, 0), shape = (5, 5))
         sliced_image = base_image[slicer]
         sliced_image += 1
 
@@ -167,7 +167,7 @@ class TestImage(unittest.TestCase):
     def test_image_manipulation(self):
 
         new_image = image.Image(
-            torch.ones((16, 32)),
+            data = torch.ones((16, 32)),
             pixelscale=1.0,
             zeropoint=1.0,
             origin=torch.zeros(2) + 0.1,
@@ -220,7 +220,7 @@ class TestImage(unittest.TestCase):
     def test_image_save_load(self):
 
         new_image = image.Image(
-            torch.ones((16, 32)),
+            data =torch.ones((16, 32)),
             pixelscale=0.76,
             zeropoint=21.4,
             origin=torch.zeros(2) + 0.1,

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -309,7 +309,7 @@ class TestTargetImage(unittest.TestCase):
     def test_psf(self):
 
         new_image = image.Target_Image(
-            data=torch.ones((16, 32)),
+            data=torch.ones((15, 33)),
             psf=torch.ones((9, 9)),
             pixelscale=1.0,
             zeropoint=1.0,
@@ -463,7 +463,7 @@ class TestJacobianImage(unittest.TestCase):
             pixelscale=1.0,
             zeropoint=1.0,
             window=ap.image.Window(
-                origin=torch.zeros(2) + 0.1, pixel_shape=torch.tensor((16, 32))
+                origin=torch.zeros(2) + 0.1, pixel_shape=torch.tensor((32, 16))
             ),
             note="test image",
         )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -21,7 +21,7 @@ class TestImage(unittest.TestCase):
         self.assertEqual(base_image.origin[1], 0, "image should track origin")
         self.assertEqual(base_image.note, "test image", "image should track note")
 
-        slicer = image.Window(origin = (3, 2), shape = (4, 5))
+        slicer = image.Window(origin = (3, 2), pixel_shape = (4, 5))
         sliced_image = base_image[slicer]
         self.assertEqual(sliced_image.origin[0], 3, "image should track origin")
         self.assertEqual(sliced_image.origin[1], 2, "image should track origin")
@@ -105,7 +105,7 @@ class TestImage(unittest.TestCase):
             origin=torch.ones(2),
             note="test image",
         )
-        slicer = image.Window(origin = (0, 0), shape = (5, 5))
+        slicer = image.Window(origin = (0, 0), pixel_shape = (5, 5))
         sliced_image = base_image[slicer]
         sliced_image += 1
 
@@ -322,11 +322,11 @@ class TestTargetImage(unittest.TestCase):
             5,
             "psf border should be half psf size, rounded up ",
         )
-        self.assertEqual(
-            new_image.psf.psf_border[0],
-            5,
-            "psf border should be half psf size, rounded up ",
-        )
+        # self.assertEqual(
+        #     new_image.psf.psf_border[0],
+        #     5,
+        #     "psf border should be half psf size, rounded up ",
+        # )
 
         reduced_image = new_image.reduce(3)
         self.assertEqual(
@@ -468,7 +468,7 @@ class TestJacobianImage(unittest.TestCase):
             pixelscale=1.0,
             zeropoint=1.0,
             window=ap.image.Window(
-                origin=torch.zeros(2) + 0.1, shape=torch.tensor((16, 32))
+                origin=torch.zeros(2) + 0.1, pixel_shape=torch.tensor((16, 32))
             ),
             note="test image",
         )
@@ -479,7 +479,7 @@ class TestJacobianImage(unittest.TestCase):
             pixelscale=1.0,
             zeropoint=1.0,
             window=ap.image.Window(
-                origin=torch.zeros(2) + 4 + 0.1, shape=torch.tensor((4, 4))
+                origin=torch.zeros(2) + 4 + 0.1, pixel_shape=torch.tensor((4, 4))
             ),
             note="other image",
         )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -250,6 +250,18 @@ class TestImage(unittest.TestCase):
             "Loaded image should have same zeropoint",
         )
 
+    def test_image_display(self):
+        new_image = image.Image(
+            data =torch.ones((16, 32)),
+            pixelscale=0.76,
+            zeropoint=21.4,
+            origin=torch.zeros(2) + 0.1,
+            note="test image",
+        )
+
+        self.assertIsInstance(str(new_image), str, "String representation should be a string!")
+        self.assertIsInstance(repr(new_image), str, "Repr should be a string!")
+
 
 class TestTargetImage(unittest.TestCase):
     def test_variance(self):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -322,11 +322,6 @@ class TestTargetImage(unittest.TestCase):
             5,
             "psf border should be half psf size, rounded up ",
         )
-        # self.assertEqual(
-        #     new_image.psf.psf_border[0],
-        #     5,
-        #     "psf border should be half psf size, rounded up ",
-        # )
 
         reduced_image = new_image.reduce(3)
         self.assertEqual(

--- a/tests/test_image_header.py
+++ b/tests/test_image_header.py
@@ -3,6 +3,8 @@ from astrophot import image
 import astrophot as ap
 import torch
 
+from utils import get_astropy_wcs
+
 ######################################################################
 # Image_Header Objects
 ######################################################################
@@ -55,4 +57,13 @@ class TestImageHeader(unittest.TestCase):
 
         self.assertTrue(torch.allclose(torch.stack(H.plane_to_world(*H.origin)), torch.ones_like(H.center) * 10), "Origin_radec provided, origin should be as given in world coordinates")
 
+        # Astropy WCS
+        wcs = get_astropy_wcs()
+        H = ap.image.Image_Header(
+            data_shape = (180,180),
+            wcs = wcs,
+        )
+
+        self.assertTrue(torch.allclose(torch.tensor(wcs.wcs.crpix), torch.stack(H.world_to_pixel(*torch.tensor(wcs.wcs.crval)))), "Astropy WCS initialization should map crval crpix coordinates")
+        
         

--- a/tests/test_image_header.py
+++ b/tests/test_image_header.py
@@ -1,0 +1,59 @@
+import unittest
+from astrophot import image
+import astrophot as ap
+import torch
+
+######################################################################
+# Image_Header Objects
+######################################################################
+
+
+class TestImageHeader(unittest.TestCase):
+    def test_image_header_creation(self):
+
+        # Minimial input
+        H = ap.image.Image_Header(
+            data_shape = (20,20),
+            zeropoint = 22.5,
+            pixelscale = 0.2,
+        )
+
+        self.assertTrue(torch.all(H.origin == 0), "Origin should be assumed zero if not given")
+
+        # Center
+        H = ap.image.Image_Header(
+            data_shape = (20,20),
+            pixelscale = 0.2,
+            center = (10,10),
+        )
+
+        self.assertTrue(torch.all(H.origin == 8), "Center provided, origin should be adjusted accordingly")
+
+        # Origin
+        H = ap.image.Image_Header(
+            data_shape = (20,20),
+            pixelscale = 0.2,
+            origin = (10,10),
+        )
+
+        self.assertTrue(torch.all(H.origin == 10), "Origin provided, origin should be as given")
+
+        # Center radec
+        H = ap.image.Image_Header(
+            data_shape = (20,20),
+            pixelscale = 0.2,
+            center_radec = (10,10),
+        )
+
+        self.assertTrue(torch.allclose(torch.stack(H.plane_to_world(*H.center)), torch.ones_like(H.center) * 10), "Center_radec provided, center should be as given in world coordinates")
+
+        # Origin radec
+        H = ap.image.Image_Header(
+            data_shape = (20,20),
+            pixelscale = 0.2,
+            origin_radec = (10,10),
+        )
+
+        self.assertTrue(torch.allclose(torch.stack(H.plane_to_world(*H.origin)), torch.ones_like(H.center) * 10), "Origin_radec provided, origin should be as given in world coordinates")
+
+        

--- a/tests/test_image_header.py
+++ b/tests/test_image_header.py
@@ -7,7 +7,6 @@ import torch
 # Image_Header Objects
 ######################################################################
 
-
 class TestImageHeader(unittest.TestCase):
     def test_image_header_creation(self):
 

--- a/tests/test_image_header.py
+++ b/tests/test_image_header.py
@@ -46,7 +46,7 @@ class TestImageHeader(unittest.TestCase):
             center_radec = (10,10),
         )
 
-        self.assertTrue(torch.allclose(torch.stack(H.plane_to_world(*H.center)), torch.ones_like(H.center) * 10), "Center_radec provided, center should be as given in world coordinates")
+        self.assertTrue(torch.allclose(H.plane_to_world(H.center), torch.ones_like(H.center) * 10), "Center_radec provided, center should be as given in world coordinates")
 
         # Origin radec
         H = ap.image.Image_Header(
@@ -55,7 +55,7 @@ class TestImageHeader(unittest.TestCase):
             origin_radec = (10,10),
         )
 
-        self.assertTrue(torch.allclose(torch.stack(H.plane_to_world(*H.origin)), torch.ones_like(H.center) * 10), "Origin_radec provided, origin should be as given in world coordinates")
+        self.assertTrue(torch.allclose(H.plane_to_world(H.origin), torch.ones_like(H.center) * 10), "Origin_radec provided, origin should be as given in world coordinates")
 
         # Astropy WCS
         wcs = get_astropy_wcs()
@@ -64,6 +64,8 @@ class TestImageHeader(unittest.TestCase):
             wcs = wcs,
         )
 
-        self.assertTrue(torch.allclose(torch.tensor(wcs.wcs.crpix), torch.stack(H.world_to_pixel(*torch.tensor(wcs.wcs.crval)))), "Astropy WCS initialization should map crval crpix coordinates")
+        sky_coord = wcs.pixel_to_world(*wcs.wcs.crpix)
+        wcs_world = torch.tensor((sky_coord.ra.deg, sky_coord.dec.deg))
+        self.assertTrue(torch.allclose(torch.tensor(wcs.wcs.crpix), H.world_to_pixel(wcs_world)), "Astropy WCS initialization should map crval crpix coordinates")
         
         

--- a/tests/test_image_header.py
+++ b/tests/test_image_header.py
@@ -69,3 +69,34 @@ class TestImageHeader(unittest.TestCase):
         self.assertTrue(torch.allclose(torch.tensor(wcs.wcs.crpix), H.world_to_pixel(wcs_world)), "Astropy WCS initialization should map crval crpix coordinates")
         
         
+    def test_image_header_wcs_roundtrip(self):
+
+        wcs = get_astropy_wcs()
+        # Minimial input
+        H = ap.image.Image_Header(
+            data_shape = (20,20),
+            zeropoint = 22.5,
+            wcs = wcs,
+        )
+
+        self.assertTrue(torch.allclose(H.world_to_plane(H.plane_to_world(torch.zeros_like(H.window.reference_radec))), torch.zeros_like(H.window.reference_radec)), "WCS world/plane roundtrip should return input value")
+        self.assertTrue(torch.allclose(H.pixel_to_plane(H.plane_to_pixel(torch.zeros_like(H.window.reference_radec))), torch.zeros_like(H.window.reference_radec)), "WCS pixel/plane roundtrip should return input value")
+        self.assertTrue(torch.allclose(H.world_to_pixel(H.pixel_to_world(torch.zeros_like(H.window.reference_radec))), torch.zeros_like(H.window.reference_radec), atol = 1e-6), "WCS world/pixel roundtrip should return input value")
+
+        self.assertTrue(torch.allclose(H.pixel_to_plane_delta(H.plane_to_pixel_delta(torch.ones_like(H.window.reference_radec))), torch.ones_like(H.window.reference_radec)), "WCS pixel/plane delta roundtrip should return input value")
+
+        
+        
+    def test_iamge_header_repr(self):
+
+        wcs = get_astropy_wcs()
+        # Minimial input
+        H = ap.image.Image_Header(
+            data_shape = (20,20),
+            zeropoint = 22.5,
+            wcs = wcs,
+        )
+
+        S = str(H)
+        R = repr(H)
+        

--- a/tests/test_image_list.py
+++ b/tests/test_image_list.py
@@ -12,7 +12,7 @@ class TestImageList(unittest.TestCase):
     def test_image_creation(self):
         arr1 = torch.zeros((10, 15))
         base_image1 = ap.image.Image(
-            arr1,
+            data=arr1,
             pixelscale=1.0,
             zeropoint=1.0,
             origin=torch.zeros(2),
@@ -20,7 +20,7 @@ class TestImageList(unittest.TestCase):
         )
         arr2 = torch.ones((15, 10))
         base_image2 = ap.image.Image(
-            arr2,
+            data=arr2,
             pixelscale=0.5,
             zeropoint=2.0,
             origin=torch.ones(2),
@@ -49,7 +49,7 @@ class TestImageList(unittest.TestCase):
             self.assertEqual(image.note, original_image.note, "image should track note")
 
         slicer = ap.image.Window_List(
-            (ap.image.Window((3, 2), (4, 5)), ap.image.Window((3, 2), (4, 5)))
+            (ap.image.Window(origin=(3, 2), shape=(4, 5)), ap.image.Window(origin=(3, 2), shape=(4, 5)))
         )
         sliced_image = test_image[slicer]
 
@@ -68,7 +68,7 @@ class TestImageList(unittest.TestCase):
 
         arr1 = torch.zeros((10, 15))
         base_image1 = ap.image.Image(
-            arr1,
+            data=arr1,
             pixelscale=1.0,
             zeropoint=1.0,
             origin=torch.zeros(2),
@@ -76,7 +76,7 @@ class TestImageList(unittest.TestCase):
         )
         arr2 = torch.ones((15, 10))
         base_image2 = ap.image.Image(
-            arr2,
+            data=arr2,
             pixelscale=0.5,
             zeropoint=2.0,
             origin=torch.ones(2),
@@ -127,7 +127,7 @@ class TestImageList(unittest.TestCase):
 
         arr1 = torch.zeros((10, 15))
         base_image1 = ap.image.Image(
-            arr1,
+            data=arr1,
             pixelscale=1.0,
             zeropoint=1.0,
             origin=torch.zeros(2),
@@ -135,7 +135,7 @@ class TestImageList(unittest.TestCase):
         )
         arr2 = torch.ones((15, 10))
         base_image2 = ap.image.Image(
-            arr2,
+            data=arr2,
             pixelscale=0.5,
             zeropoint=2.0,
             origin=torch.ones(2),
@@ -145,7 +145,7 @@ class TestImageList(unittest.TestCase):
 
         arr3 = torch.ones((10, 15))
         base_image3 = ap.image.Image(
-            arr3,
+            data=arr3,
             pixelscale=1.0,
             zeropoint=1.0,
             origin=torch.ones(2),
@@ -153,7 +153,7 @@ class TestImageList(unittest.TestCase):
         )
         arr4 = torch.zeros((15, 10))
         base_image4 = ap.image.Image(
-            arr4,
+            data=arr4,
             pixelscale=0.5,
             zeropoint=2.0,
             origin=torch.zeros(2),

--- a/tests/test_image_list.py
+++ b/tests/test_image_list.py
@@ -49,7 +49,7 @@ class TestImageList(unittest.TestCase):
             self.assertEqual(image.note, original_image.note, "image should track note")
 
         slicer = ap.image.Window_List(
-            (ap.image.Window(origin=(3, 2), shape=(4, 5)), ap.image.Window(origin=(3, 2), shape=(4, 5)))
+            (ap.image.Window(origin=(3, 2), pixel_shape=(4, 5)), ap.image.Window(origin=(3, 2), pixel_shape=(4, 5)))
         )
         sliced_image = test_image[slicer]
 
@@ -257,10 +257,14 @@ class TestModelImageList(unittest.TestCase):
             "adding then subtracting should give the same image",
         )
 
+        print(test_image.data)
         test_image.clear_image()
+        print(test_image.data)
         test_image.replace(second_image)
+        print(test_image.data)
 
         test_image -= (1, 1)
+        print(test_image.data)
 
         self.assertTrue(
             torch.all(test_image[0].data == save_image[0].data),
@@ -345,7 +349,7 @@ class TestJacobianImageList(unittest.TestCase):
             zeropoint=1.0,
             note="test image 1",
             window=ap.image.Window(
-                origin=torch.zeros(2) + 0.1, shape=torch.tensor((15, 10))
+                origin=torch.zeros(2) + 0.1, pixel_shape=torch.tensor((15, 10))
             ),
         )
         arr2 = torch.ones((15, 10, 3))
@@ -357,7 +361,7 @@ class TestJacobianImageList(unittest.TestCase):
             zeropoint=2.0,
             note="test image 2",
             window=ap.image.Window(
-                origin=torch.zeros(2) + 0.2, shape=torch.tensor((10, 15))
+                origin=torch.zeros(2) + 0.2, pixel_shape=torch.tensor((10, 15))
             ),
         )
 

--- a/tests/test_image_list.py
+++ b/tests/test_image_list.py
@@ -193,6 +193,29 @@ class TestImageList(unittest.TestCase):
             test_image[1].data[1][1], 1, "image addition should update its region"
         )
 
+    def test_image_list_display(self):
+        arr1 = torch.zeros((10, 15))
+        base_image1 = ap.image.Image(
+            data=arr1,
+            pixelscale=1.0,
+            zeropoint=1.0,
+            origin=torch.zeros(2),
+            note="test image 1",
+        )
+        arr2 = torch.ones((15, 10))
+        base_image2 = ap.image.Image(
+            data=arr2,
+            pixelscale=0.5,
+            zeropoint=2.0,
+            origin=torch.ones(2),
+            note="test image 2",
+        )
+        test_image = ap.image.Image_List((base_image1, base_image2))
+
+        self.assertIsInstance(str(test_image), str, "String representation should be a string!")
+        self.assertIsInstance(repr(test_image), str, "Repr should be a string!")
+        
+
 
 class TestModelImageList(unittest.TestCase):
     def test_model_image_list_creation(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -271,6 +271,44 @@ class TestGroup(unittest.TestCase):
 
         self.assertTrue(torch.all(smod().data == 0), "model_image should be zeros")
 
+    def test_jointmodel_creation(self):
+        np.random.seed(12345)
+        shape = (10, 15)
+        tar = ap.image.Target_Image(
+            data=np.random.normal(loc=0, scale=1.4, size=shape),
+            pixelscale=0.8,
+            variance=np.ones(shape) * (1.4 ** 2),
+        )
+        shape2 = (33, 42)
+        tar2 = ap.image.Target_Image(
+            data=np.random.normal(loc=0, scale=1.4, size=shape2),
+            pixelscale=0.3,
+            origin = (43.2, 78.01),
+            variance=np.ones(shape2) * (1.4 ** 2),
+        )
+
+        mod1 = ap.models.Flat_Sky(
+            name="base model 1",
+            target=tar,
+        )
+        mod2 = ap.models.Flat_Sky(
+            name="base model 2",
+            target=tar2,
+        )
+
+        smod = ap.models.AstroPhot_Model(
+            name="group model",
+            model_type="group model",
+            model_list=[mod1, mod2],
+            target=tar,
+        )
+
+        self.assertFalse(smod.locked, "default model state should not be locked")
+
+        smod.initialize()
+
+        self.assertTrue(torch.all(torch.isfinite(smod().data)), "model_image should be real")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -3,7 +3,6 @@ import astrophot as ap
 import numpy as np
 import torch
 
-
 class TestWCS(unittest.TestCase):
     def test_wcs_creation(self):
 

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -1,0 +1,61 @@
+import unittest
+import astrophot as ap
+import numpy as np
+import torch
+
+
+class TestWCS(unittest.TestCase):
+    def test_wcs_creation(self):
+
+        # Blank startup
+        wcs_blank = ap.image.WCS()
+
+        self.assertEqual(wcs_blank.projection, "gnomonic", "Default projection should be Gnomonic")
+        self.assertTrue(torch.all(wcs_blank.reference_radec == 0), "default reference world coordinates should be zeros")
+
+        # Provided parameters
+        ap.image.WCS._projection = None # reset
+        ap.image.WCS._reference_radec = None # reset
+        wcs_set = ap.image.WCS(
+            projection = "orthographic",
+            reference_radec = (90,10),
+        )
+
+        self.assertEqual(wcs_set.projection, "orthographic", "Provided projection was Orthographic")
+        self.assertTrue(torch.all(wcs_set.reference_radec == torch.tensor((90,10))), "World coordinates should be as provided")
+        self.assertEqual(wcs_blank.projection, "orthographic", "All WCS objects should be updated")
+        self.assertTrue(torch.all(wcs_blank.reference_radec == torch.tensor((90,10))), "All WCS objects should be updated")
+        
+
+    def test_wcs_round_trip(self):
+
+        for projection in ["gnomonic", "orthographic", "steriographic"]:
+            print(projection)
+            for ref_coords in [(20.3, 79), (120.2,-19), (300, -50), (0,0)]:
+                print(ref_coords)
+                ap.image.WCS._projection = None # reset
+                ap.image.WCS._reference_radec = None # reset
+                wcs = ap.image.WCS(
+                    projection = projection,
+                    reference_radec = ref_coords,
+                )
+
+                test_grid_RA, test_grid_DEC = torch.meshgrid(
+                    torch.linspace(ref_coords[0] - 10, ref_coords[0] + 10, 10, dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device), # RA
+                    torch.linspace(ref_coords[1] - 10, ref_coords[1] + 10, 10, dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device), # DEC
+                    indexing = "xy",
+                )
+
+                project_x, project_y = wcs.world_to_plane(
+                    test_grid_RA,
+                    test_grid_DEC,
+                )
+
+                reproject_RA, reproject_DEC = wcs.plane_to_world(
+                    project_x,
+                    project_y,
+                )
+
+                self.assertTrue(torch.allclose(reproject_RA, test_grid_RA), "Round trip RA should map back to itself")
+                self.assertTrue(torch.allclose(reproject_DEC, test_grid_DEC), "Round trip DEC should map back to itself")
+            

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -23,8 +23,8 @@ class TestWCS(unittest.TestCase):
 
         self.assertEqual(wcs_set.projection, "orthographic", "Provided projection was Orthographic")
         self.assertTrue(torch.all(wcs_set.reference_radec == torch.tensor((90,10))), "World coordinates should be as provided")
-        self.assertEqual(wcs_blank.projection, "orthographic", "All WCS objects should be updated")
-        self.assertTrue(torch.all(wcs_blank.reference_radec == torch.tensor((90,10))), "All WCS objects should be updated")
+        self.assertNotEqual(wcs_blank.projection, "orthographic", "Not all WCS objects should be updated")
+        self.assertFalse(torch.all(wcs_blank.reference_radec == torch.tensor((90,10))), "Not all WCS objects should be updated")
         
 
     def test_wcs_round_trip(self):

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -7,15 +7,15 @@ class TestWCS(unittest.TestCase):
     def test_wcs_creation(self):
 
         # Blank startup
-        wcs_blank = ap.image.WCS()
+        wcs_blank = ap.image.WPCS()
 
         self.assertEqual(wcs_blank.projection, "gnomonic", "Default projection should be Gnomonic")
         self.assertTrue(torch.all(wcs_blank.reference_radec == 0), "default reference world coordinates should be zeros")
 
         # Provided parameters
-        ap.image.WCS._projection = None # reset
-        ap.image.WCS._reference_radec = None # reset
-        wcs_set = ap.image.WCS(
+        ap.image.WPCS._projection = None # reset
+        ap.image.WPCS._reference_radec = None # reset
+        wcs_set = ap.image.WPCS(
             projection = "orthographic",
             reference_radec = (90,10),
         )
@@ -32,9 +32,9 @@ class TestWCS(unittest.TestCase):
             print(projection)
             for ref_coords in [(20.3, 79), (120.2,-19), (300, -50), (0,0)]:
                 print(ref_coords)
-                ap.image.WCS._projection = None # reset
-                ap.image.WCS._reference_radec = None # reset
-                wcs = ap.image.WCS(
+                ap.image.WPCS._projection = None # reset
+                ap.image.WPCS._reference_radec = None # reset
+                wcs = ap.image.WPCS(
                     projection = projection,
                     reference_radec = ref_coords,
                 )

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -3,18 +3,17 @@ import astrophot as ap
 import numpy as np
 import torch
 
-class TestWCS(unittest.TestCase):
-    def test_wcs_creation(self):
+class TestWPCS(unittest.TestCase):
+    def test_wpcs_creation(self):
 
         # Blank startup
         wcs_blank = ap.image.WPCS()
 
         self.assertEqual(wcs_blank.projection, "gnomonic", "Default projection should be Gnomonic")
         self.assertTrue(torch.all(wcs_blank.reference_radec == 0), "default reference world coordinates should be zeros")
+        self.assertTrue(torch.all(wcs_blank.reference_planexy == 0), "default reference plane coordinates should be zeros")
 
         # Provided parameters
-        ap.image.WPCS._projection = None # reset
-        ap.image.WPCS._reference_radec = None # reset
         wcs_set = ap.image.WPCS(
             projection = "orthographic",
             reference_radec = (90,10),
@@ -26,14 +25,12 @@ class TestWCS(unittest.TestCase):
         self.assertFalse(torch.all(wcs_blank.reference_radec == torch.tensor((90,10))), "Not all WCS objects should be updated")
         
 
-    def test_wcs_round_trip(self):
+    def test_wpcs_round_trip(self):
 
         for projection in ["gnomonic", "orthographic", "steriographic"]:
             print(projection)
             for ref_coords in [(20.3, 79), (120.2,-19), (300, -50), (0,0)]:
                 print(ref_coords)
-                ap.image.WPCS._projection = None # reset
-                ap.image.WPCS._reference_radec = None # reset
                 wcs = ap.image.WPCS(
                     projection = projection,
                     reference_radec = ref_coords,
@@ -58,3 +55,110 @@ class TestWCS(unittest.TestCase):
                 self.assertTrue(torch.allclose(reproject_RA, test_grid_RA), "Round trip RA should map back to itself")
                 self.assertTrue(torch.allclose(reproject_DEC, test_grid_DEC), "Round trip DEC should map back to itself")
             
+class TestPPCS(unittest.TestCase):
+
+    def test_ppcs_creation(self):
+        # Blank startup
+        wcs_blank = ap.image.PPCS()
+
+        self.assertTrue(np.all(wcs_blank.pixelscale.detach().cpu().numpy() == np.array([[1.,0.],[0.,1.]])), "Default pixelscale should be 1")
+        self.assertTrue(torch.all(wcs_blank.reference_imageij == -0.5), "default reference pixel coordinates should be -0.5")
+        self.assertTrue(torch.all(wcs_blank.reference_imagexy == 0.), "default reference plane coordinates should be zeros")
+
+        # Provided parameters
+        wcs_set = ap.image.PPCS(
+            pixelscale = [[-0.173205, 0.1],[0.15,0.259808]],
+            reference_imageij = (5,10),
+            reference_imagexy = (0.12, 0.45),
+        )
+
+        self.assertTrue(torch.allclose(wcs_set.pixelscale, torch.tensor([[-0.173205, 0.1],[0.15,0.259808]], dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "Provided pixelscale should be used")
+        self.assertTrue(torch.allclose(wcs_set.reference_imageij, torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should be as provided")
+        self.assertTrue(torch.allclose(wcs_set.reference_imagexy, torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should be as provided")
+        self.assertTrue(torch.allclose(wcs_set.plane_to_pixel(torch.tensor((0.12,0.45))), torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should map to pixel reference coordinates")
+        self.assertTrue(torch.allclose(wcs_set.pixel_to_plane(torch.tensor((5.,10.))), torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should map to plane reference coordinates")
+        
+    def test_ppcs_round_trip(self):
+
+        for pixelscale in [0.2, [[0.6, 0.],[0., 0.4]], [[-0.173205, 0.1],[0.15,0.259808]]]:
+            print(pixelscale)
+            for ref_coords in [(20.3, 79), (120.2,-19), (300, -50), (0,0)]:
+                print(ref_coords)
+                wcs = ap.image.PPCS(
+                    pixelscale = pixelscale,
+                    reference_imagexy = ref_coords,
+                )
+
+                test_grid_x, test_grid_y = torch.meshgrid(
+                    torch.linspace(ref_coords[0] - 10, ref_coords[0] + 10, 10, dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device), # x
+                    torch.linspace(ref_coords[1] - 10, ref_coords[1] + 10, 10, dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device), # y
+                    indexing = "xy",
+                )
+
+                project_i, project_j = wcs.plane_to_pixel(
+                    test_grid_x,
+                    test_grid_y,
+                )
+
+                reproject_x, reproject_y = wcs.pixel_to_plane(
+                    project_i,
+                    project_j,
+                )
+
+                self.assertTrue(torch.allclose(reproject_x, test_grid_x), "Round trip x should map back to itself")
+                self.assertTrue(torch.allclose(reproject_y, test_grid_y), "Round trip y should map back to itself")
+
+class TestWCS(unittest.TestCase):
+
+    def test_wcs_roundtrip(self):
+        for pixelscale in [0.2, [[0.6, 0.],[0., 0.4]], [[-0.173205, 0.1],[0.15,0.259808]]]:
+            print(pixelscale)
+            for ref_coords_xy in [(33., 123.), (-430.2,-11), (-97., 5), (0,0)]:
+                for projection in ["gnomonic", "orthographic", "steriographic"]:
+                    print(projection)
+                    for ref_coords_radec in [(20.3, 79), (120.2,-19), (300, -50), (0,0)]:
+                        print(ref_coords_radec)
+                        wcs = ap.image.WCS(
+                            projection = projection,
+                            pixelscale = pixelscale,
+                            reference_radec = ref_coords_radec,
+                            reference_imagexy = ref_coords_xy,
+                        )
+
+                        
+                        test_grid_RA, test_grid_DEC = torch.meshgrid(
+                            torch.linspace(ref_coords_radec[0] - 10, ref_coords_radec[0] + 10, 10, dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device), # RA
+                            torch.linspace(ref_coords_radec[1] - 10, ref_coords_radec[1] + 10, 10, dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device), # DEC
+                            indexing = "xy",
+                        )
+                        
+                        project_i, project_j = wcs.world_to_pixel(
+                            test_grid_RA,
+                            test_grid_DEC,
+                        )
+                        
+                        reproject_RA, reproject_DEC = wcs.pixel_to_world(
+                            project_i,
+                            project_j,
+                        )
+                        
+                        self.assertTrue(torch.allclose(reproject_RA, test_grid_RA), "Round trip RA should map back to itself")
+                        self.assertTrue(torch.allclose(reproject_DEC, test_grid_DEC), "Round trip DEC should map back to itself")
+    
+
+    def test_wcs_state(self):
+        wcs = ap.image.WCS(
+            projection = "orthographic",
+            pixelscale = [[-0.173205, 0.1],[0.15,0.259808]],
+            reference_radec = (120.2,-19),
+            reference_imagexy = (33., 123.),
+        )
+
+        wcs_state = wcs.get_state()
+
+        new_wcs = ap.image.WCS(state = wcs_state)
+
+        self.assertEqual(wcs.projection, new_wcs.projection, "WCS projection should be set by state")
+        self.assertTrue(torch.allclose(wcs.pixelscale, torch.tensor([[-0.173205, 0.1],[0.15,0.259808]], dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "WCS pixelscale should be set by state")
+        self.assertTrue(torch.allclose(wcs.reference_radec, torch.tensor((120.2,-19), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "WCS reference RA DEC should be set by state")
+        self.assertTrue(torch.allclose(wcs.reference_imagexy, torch.tensor((33., 123.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "WCS reference image position should be set by state")

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -550,7 +550,7 @@ class TestWindow(unittest.TestCase):
 
     def test_window_state(self):
 
-        window = ap.image.Window(state={"origin": [1.0, 2.0], "shape": [10, 15], "pixelshape": [[1.,0.],[0.,1.]]})
+        window = ap.image.Window(state={"origin": [1.0, 2.0], "shape": [10, 15], "pixelshape": [[1.,0.],[0.,1.]], "projection": "orthographic", "reference_radec": (0,0)})
         self.assertEqual(
             window.origin[0].item(), 1.0, "Window initialization should read state"
         )
@@ -570,6 +570,12 @@ class TestWindow(unittest.TestCase):
         )
         self.assertEqual(
             state["pixelshape"][1][0], 0.0, "Window get state should collect values"
+        )
+        self.assertEqual(
+            state["projection"], "orthographic", "Window get state should collect values"
+        )
+        self.assertEqual(
+            state["reference_radec"], (0.,0.), "Window get state should collect values"
         )
 
     def test_window_logic(self):

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -7,7 +7,7 @@ import torch
 class TestWindow(unittest.TestCase):
     def test_window_creation(self):
 
-        window1 = ap.image.Window(origin = (0, 6), shape = (100, 110))
+        window1 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
 
         window1.to(dtype=torch.float64, device="cpu")
 
@@ -20,21 +20,21 @@ class TestWindow(unittest.TestCase):
 
         self.assertRaises(Exception, ap.image.Window)
 
-        shape = window1.get_shape(torch.tensor([[10.0,0.],[0.,10.0]], dtype = ap.AP_config.ap_dtype))
-        self.assertEqual(
-            shape[0].item(), 10, "Window shape in pixels should divide by pixelscale"
-        )
-        shape = window1.get_shape_flip(torch.tensor([[5.0,0.],[0.,5.0]], dtype = ap.AP_config.ap_dtype))
-        self.assertEqual(
-            shape[0].item(), 22, "Window shape in pixels should divide by pixelscale"
-        )
+        # shape = window1.get_shape(torch.tensor([[10.0,0.],[0.,10.0]], dtype = ap.AP_config.ap_dtype))
+        # self.assertEqual(
+        #     shape[0].item(), 10, "Window shape in pixels should divide by pixelscale"
+        # )
+        # shape = window1.get_shape_flip(torch.tensor([[5.0,0.],[0.,5.0]], dtype = ap.AP_config.ap_dtype))
+        # self.assertEqual(
+        #     shape[0].item(), 22, "Window shape in pixels should divide by pixelscale"
+        # )
 
         x = str(window1)
 
     def test_window_arithmetic(self):
 
-        windowbig = ap.image.Window(origin = (0, 0), shape = (100, 110))
-        windowsmall = ap.image.Window(origin = (40, 40), shape = (20, 30))
+        windowbig = ap.image.Window(origin = (0, 0), pixel_shape = (100, 110))
+        windowsmall = ap.image.Window(origin = (40, 40), pixel_shape = (20, 30))
 
         # Logical or, size
         ######################################################################
@@ -111,7 +111,7 @@ class TestWindow(unittest.TestCase):
 
         # Logical or, offset
         ######################################################################
-        windowoffset = ap.image.Window(origin = (40, -20), shape = (100, 90))
+        windowoffset = ap.image.Window(origin = (40, -20), pixel_shape = (100, 90))
         big_or_offset = windowbig | windowoffset
         self.assertEqual(
             big_or_offset.origin[0],
@@ -258,7 +258,7 @@ class TestWindow(unittest.TestCase):
 
         # Logical iand, offset
         ######################################################################
-        windowbig = ap.image.Window(origin = (0, 0), shape = (100, 110))
+        windowbig = ap.image.Window(origin = (0, 0), pixel_shape = (100, 110))
         windowbig &= windowoffset
         self.assertEqual(
             windowbig.origin[0], 40, "logical and of images should take overlap region"
@@ -291,266 +291,266 @@ class TestWindow(unittest.TestCase):
             "logical and of images should take overlap region, equality should be internally determined",
         )
 
-    def test_window_buffering(self):
+    # def test_window_buffering(self):
 
-        window = ap.image.Window(origin = (0, 0), shape = (100, 110))
+    #     window = ap.image.Window(origin = (0, 0), shape = (100, 110))
 
         # Multiply
         ######################################################################
-        window_scaled = window * 2
-        self.assertEqual(
-            window_scaled.origin[0], -50, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[0], 200, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.origin[1], -55, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[1], 220, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window scaling should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window scaling should not affect initial images"
-        )
-        window_scaled = window * (2, 1)
-        self.assertEqual(
-            window_scaled.origin[0], -50, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[0], 200, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.origin[1], 0, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[1], 110, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window scaling should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window scaling should not affect initial images"
-        )
+        # window_scaled = window * 2
+        # self.assertEqual(
+        #     window_scaled.origin[0], -50, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[0], 200, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.origin[1], -55, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[1], 220, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window scaling should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window scaling should not affect initial images"
+        # )
+        # window_scaled = window * (2, 1)
+        # self.assertEqual(
+        #     window_scaled.origin[0], -50, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[0], 200, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.origin[1], 0, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[1], 110, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window scaling should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window scaling should not affect initial images"
+        # )
 
         # Divide
         ######################################################################
-        window_scaled = window / 2
-        self.assertEqual(
-            window_scaled.origin[0], 25, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[0], 50, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.origin[1], 27.5, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[1], 55, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window scaling should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window scaling should not affect initial images"
-        )
-        window_scaled = window / (2, 1)
-        self.assertEqual(
-            window_scaled.origin[0], 25, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[0], 50, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.origin[1], 0, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[1], 110, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window scaling should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window scaling should not affect initial images"
-        )
+        # window_scaled = window / 2
+        # self.assertEqual(
+        #     window_scaled.origin[0], 25, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[0], 50, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.origin[1], 27.5, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[1], 55, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window scaling should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window scaling should not affect initial images"
+        # )
+        # window_scaled = window / (2, 1)
+        # self.assertEqual(
+        #     window_scaled.origin[0], 25, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[0], 50, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.origin[1], 0, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_scaled.shape[1], 110, "Window scaling should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window scaling should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window scaling should not affect initial images"
+        # )
 
         # Add
         ######################################################################
-        window_buffer = window + 10
-        self.assertEqual(
-            window_buffer.origin[0], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 130, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
-        window_buffer = window + (10.0, 5.0)
-        self.assertEqual(
-            window_buffer.origin[0], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], -5, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
+        # window_buffer = window + 10
+        # self.assertEqual(
+        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], -10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 130, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
+        # window_buffer = window + (10.0, 5.0)
+        # self.assertEqual(
+        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], -5, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 120, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
 
         # Subtract
         ######################################################################
-        window_buffer = window - 10
-        self.assertEqual(
-            window_buffer.origin[0], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 80, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 90, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
-        window_buffer = window - (10.0, 5.0)
-        self.assertEqual(
-            window_buffer.origin[0], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 80, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], 5, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 100, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
+        # window_buffer = window - 10
+        # self.assertEqual(
+        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], 10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 90, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
+        # window_buffer = window - (10.0, 5.0)
+        # self.assertEqual(
+        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], 5, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 100, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
 
         # iAdd
         ######################################################################
-        window_buffer = window.copy()
-        window_buffer += 10
-        self.assertEqual(
-            window_buffer.origin[0], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 130, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
-        window_buffer = window.copy()
-        window_buffer += (10.0, 5.0)
-        self.assertEqual(
-            window_buffer.origin[0], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], -5, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
+        # window_buffer = window.copy()
+        # window_buffer += 10
+        # self.assertEqual(
+        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], -10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 130, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
+        # window_buffer = window.copy()
+        # window_buffer += (10.0, 5.0)
+        # self.assertEqual(
+        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], -5, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 120, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
 
         # iSubtract
         ######################################################################
-        window_buffer = window.copy()
-        window_buffer -= 10
-        self.assertEqual(
-            window_buffer.origin[0], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 80, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 90, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
-        window_buffer = window.copy()
-        window_buffer -= (10.0, 5.0)
-        self.assertEqual(
-            window_buffer.origin[0], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0], 80, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1], 5, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1], 100, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0], 100, "Window buffering should not affect initial images"
-        )
+        # window_buffer = window.copy()
+        # window_buffer -= 10
+        # self.assertEqual(
+        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], 10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 90, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
+        # window_buffer = window.copy()
+        # window_buffer -= (10.0, 5.0)
+        # self.assertEqual(
+        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.origin[1], 5, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window_buffer.shape[1], 100, "Window buffer should remain centered"
+        # )
+        # self.assertEqual(
+        #     window.origin[0], 0, "Window buffering should not affect initial images"
+        # )
+        # self.assertEqual(
+        #     window.shape[0], 100, "Window buffering should not affect initial images"
+        # )
 
-        window.shift_origin(torch.tensor(1.0))
-        self.assertEqual(window.origin[0].item(), 1.0, "Origin should be moved")
+        # window.shift_origin(torch.tensor(1.0))
+        # self.assertEqual(window.origin[0].item(), 1.0, "Origin should be moved")
 
     def test_window_state(self):
-
-        window = ap.image.Window(state={"origin": [1.0, 2.0], "shape": [10, 15], "pixelshape": [[1.,0.],[0.,1.]], "projection": "orthographic", "reference_radec": (0,0)})
+        window_init = ap.image.Window(origin = [1.0, 2.0], pixel_shape = [10, 15], pixelscale = 1, projection = "orthographic", reference_radec = (0,0))
+        window = ap.image.Window(state=window_init.get_state())
         self.assertEqual(
             window.origin[0].item(), 1.0, "Window initialization should read state"
         )
@@ -558,18 +558,18 @@ class TestWindow(unittest.TestCase):
             window.shape[0].item(), 10.0, "Window initialization should read state"
         )
         self.assertEqual(
-            window.pixelshape[0][0].item(), 1.0, "Window initialization should read state"
+            window.pixelscale[0][0].item(), 1.0, "Window initialization should read state"
         )
 
         state = window.get_state()
         self.assertEqual(
-            state["origin"][1], 2.0, "Window get state should collect values"
+            state["reference_imagexy"][1], 2.0, "Window get state should collect values"
         )
         self.assertEqual(
-            state["shape"][1], 15.0, "Window get state should collect values"
+            state["pixel_shape"][1], 15.0, "Window get state should collect values"
         )
         self.assertEqual(
-            state["pixelshape"][1][0], 0.0, "Window get state should collect values"
+            state["pixelscale"][1][0], 0.0, "Window get state should collect values"
         )
         self.assertEqual(
             state["projection"], "orthographic", "Window get state should collect values"
@@ -580,9 +580,9 @@ class TestWindow(unittest.TestCase):
 
     def test_window_logic(self):
 
-        window1 = ap.image.Window(origin=[0.0, 1.0], shape=[10.2, 11.8])
-        window2 = ap.image.Window(origin=[0.0, 1.0], shape=[10.2, 11.8])
-        window3 = ap.image.Window(origin=[-0.6, 0.4], shape=[15.2, 18.0])
+        window1 = ap.image.Window(origin=[0.0, 1.0],  pixel_shape=[10.2, 11.8])
+        window2 = ap.image.Window(origin=[0.0, 1.0],  pixel_shape=[10.2, 11.8])
+        window3 = ap.image.Window(origin=[-0.6, 0.4], pixel_shape=[15.2, 18.0])
 
         self.assertEqual(
             window1, window2, "same origin, shape windows should evaluate equal"
@@ -590,18 +590,18 @@ class TestWindow(unittest.TestCase):
         self.assertNotEqual(
             window1, window3, "Differnt windows should not evaluate equal"
         )
-        self.assertTrue(
-            window3 > window1, "Window3 should be identified as larger than window1"
-        )
-        self.assertTrue(
-            window3 >= window1, "Window3 should be identified as larger than window1"
-        )
-        self.assertTrue(
-            window1 < window3, "Window1 should be identified as smaller than window3"
-        )
-        self.assertTrue(
-            window1 <= window3, "Window1 should be identified as smaller than window3"
-        )
+        # self.assertTrue(
+        #     window3 > window1, "Window3 should be identified as larger than window1"
+        # )
+        # self.assertTrue(
+        #     window3 >= window1, "Window3 should be identified as larger than window1"
+        # )
+        # self.assertTrue(
+        #     window1 < window3, "Window1 should be identified as smaller than window3"
+        # )
+        # self.assertTrue(
+        #     window1 <= window3, "Window1 should be identified as smaller than window3"
+        # )
 
 
 if __name__ == "__main__":

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -23,6 +23,8 @@ class TestWindow(unittest.TestCase):
         x = str(window1)
         x = repr(window1)
 
+        wcs = window1.get_astropywcs()
+
     def test_window_crop(self):
         
         window1 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -31,6 +31,27 @@ class TestWindow(unittest.TestCase):
 
         x = str(window1)
 
+    def test_window_crop(self):
+        
+        window1 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
+
+        window1.crop_to_pixel([[10,90],[15,105]])
+
+        self.assertTrue(np.all(window1.origin.detach().cpu().numpy() == np.array([10., 21])), "crop pixels should move origin")
+        self.assertTrue(np.all(window1.pixel_shape.detach().cpu().numpy() == np.array([80, 90])), "crop pixels should change shape")
+
+    def test_window_get_indices(self):
+
+        window1 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
+        xstep, ystep = np.meshgrid(range(100), range(110), indexing = "xy")
+        zstep = xstep + ystep
+        window2 = ap.image.Window(origin = (15, 15), pixel_shape = (30, 200))
+
+        zsliced = zstep[window1.get_self_indices(window2)]
+        self.assertTrue(np.all(zsliced == zstep[9:110,15:45]), "window slices should get correct part of image")
+        zsliced = zstep[window2.get_other_indices(window1)]
+        self.assertTrue(np.all(zsliced == zstep[9:110,15:45]), "window slices should get correct part of image")
+
     def test_window_arithmetic(self):
 
         windowbig = ap.image.Window(origin = (0, 0), pixel_shape = (100, 110))
@@ -580,9 +601,9 @@ class TestWindow(unittest.TestCase):
 
     def test_window_logic(self):
 
-        window1 = ap.image.Window(origin=[0.0, 1.0],  pixel_shape=[10.2, 11.8])
-        window2 = ap.image.Window(origin=[0.0, 1.0],  pixel_shape=[10.2, 11.8])
-        window3 = ap.image.Window(origin=[-0.6, 0.4], pixel_shape=[15.2, 18.0])
+        window1 = ap.image.Window(origin=[0.0, 1.0],  pixel_shape=[10., 11.])
+        window2 = ap.image.Window(origin=[0.0, 1.0],  pixel_shape=[10., 11.])
+        window3 = ap.image.Window(origin=[-0.6, 0.4], pixel_shape=[15., 18.])
 
         self.assertEqual(
             window1, window2, "same origin, shape windows should evaluate equal"

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -7,7 +7,7 @@ import torch
 class TestWindow(unittest.TestCase):
     def test_window_creation(self):
 
-        window1 = ap.image.Window((0, 6), (100, 110))
+        window1 = ap.image.Window(origin = (0, 6), shape = (100, 110))
 
         window1.to(dtype=torch.float64, device="cpu")
 
@@ -18,7 +18,7 @@ class TestWindow(unittest.TestCase):
         self.assertEqual(window1.center[0], 50.0, "Window should determine center")
         self.assertEqual(window1.center[1], 61.0, "Window should determine center")
 
-        self.assertRaises(ValueError, ap.image.Window)
+        self.assertRaises(Exception, ap.image.Window)
 
         shape = window1.get_shape(torch.tensor([[10.0,0.],[0.,10.0]], dtype = ap.AP_config.ap_dtype))
         self.assertEqual(
@@ -33,8 +33,8 @@ class TestWindow(unittest.TestCase):
 
     def test_window_arithmetic(self):
 
-        windowbig = ap.image.Window((0, 0), (100, 110))
-        windowsmall = ap.image.Window((40, 40), (20, 30))
+        windowbig = ap.image.Window(origin = (0, 0), shape = (100, 110))
+        windowsmall = ap.image.Window(origin = (40, 40), shape = (20, 30))
 
         # Logical or, size
         ######################################################################
@@ -111,7 +111,7 @@ class TestWindow(unittest.TestCase):
 
         # Logical or, offset
         ######################################################################
-        windowoffset = ap.image.Window((40, -20), (100, 90))
+        windowoffset = ap.image.Window(origin = (40, -20), shape = (100, 90))
         big_or_offset = windowbig | windowoffset
         self.assertEqual(
             big_or_offset.origin[0],
@@ -258,7 +258,7 @@ class TestWindow(unittest.TestCase):
 
         # Logical iand, offset
         ######################################################################
-        windowbig = ap.image.Window((0, 0), (100, 110))
+        windowbig = ap.image.Window(origin = (0, 0), shape = (100, 110))
         windowbig &= windowoffset
         self.assertEqual(
             windowbig.origin[0], 40, "logical and of images should take overlap region"
@@ -293,7 +293,7 @@ class TestWindow(unittest.TestCase):
 
     def test_window_buffering(self):
 
-        window = ap.image.Window((0, 0), (100, 110))
+        window = ap.image.Window(origin = (0, 0), shape = (100, 110))
 
         # Multiply
         ######################################################################
@@ -550,7 +550,7 @@ class TestWindow(unittest.TestCase):
 
     def test_window_state(self):
 
-        window = ap.image.Window(state={"origin": [1.0, 2.0], "shape": [10, 15], "projection": [[1.,0.],[0.,1.]]})
+        window = ap.image.Window(state={"origin": [1.0, 2.0], "shape": [10, 15], "pixelshape": [[1.,0.],[0.,1.]]})
         self.assertEqual(
             window.origin[0].item(), 1.0, "Window initialization should read state"
         )
@@ -558,7 +558,7 @@ class TestWindow(unittest.TestCase):
             window.shape[0].item(), 10.0, "Window initialization should read state"
         )
         self.assertEqual(
-            window.projection[0][0].item(), 1.0, "Window initialization should read state"
+            window.pixelshape[0][0].item(), 1.0, "Window initialization should read state"
         )
 
         state = window.get_state()
@@ -569,7 +569,7 @@ class TestWindow(unittest.TestCase):
             state["shape"][1], 15.0, "Window get state should collect values"
         )
         self.assertEqual(
-            state["projection"][1][0], 0.0, "Window get state should collect values"
+            state["pixelshape"][1][0], 0.0, "Window get state should collect values"
         )
 
     def test_window_logic(self):

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -20,26 +20,38 @@ class TestWindow(unittest.TestCase):
 
         self.assertRaises(Exception, ap.image.Window)
 
-        # shape = window1.get_shape(torch.tensor([[10.0,0.],[0.,10.0]], dtype = ap.AP_config.ap_dtype))
-        # self.assertEqual(
-        #     shape[0].item(), 10, "Window shape in pixels should divide by pixelscale"
-        # )
-        # shape = window1.get_shape_flip(torch.tensor([[5.0,0.],[0.,5.0]], dtype = ap.AP_config.ap_dtype))
-        # self.assertEqual(
-        #     shape[0].item(), 22, "Window shape in pixels should divide by pixelscale"
-        # )
-
         x = str(window1)
+        x = repr(window1)
 
     def test_window_crop(self):
         
         window1 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
 
         window1.crop_to_pixel([[10,90],[15,105]])
-
         self.assertTrue(np.all(window1.origin.detach().cpu().numpy() == np.array([10., 21])), "crop pixels should move origin")
         self.assertTrue(np.all(window1.pixel_shape.detach().cpu().numpy() == np.array([80, 90])), "crop pixels should change shape")
 
+        window2 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
+        window2.crop_pixel((5,))
+        self.assertTrue(np.all(window2.origin.detach().cpu().numpy() == np.array([5., 11.])), "crop pixels should move origin")
+        self.assertTrue(np.all(window2.pixel_shape.detach().cpu().numpy() == np.array([90, 100])), "crop pixels should change shape")
+        window2.pad_pixel((5,))
+
+        window2 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
+        window2.crop_pixel((5,6))
+        self.assertTrue(np.all(window2.origin.detach().cpu().numpy() == np.array([5., 12.])), "crop pixels should move origin")
+        self.assertTrue(np.all(window2.pixel_shape.detach().cpu().numpy() == np.array([90, 98])), "crop pixels should change shape")
+        window2.pad_pixel((5,6))
+
+        window2 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
+        window2.crop_pixel((5,6,7,8))
+        self.assertTrue(np.all(window2.origin.detach().cpu().numpy() == np.array([5., 12.])), "crop pixels should move origin")
+        self.assertTrue(np.all(window2.pixel_shape.detach().cpu().numpy() == np.array([88, 96])), "crop pixels should change shape")
+        window2.pad_pixel((5,6,7,8))
+
+        self.assertTrue(np.all(window2.origin.detach().cpu().numpy() == np.array([0., 6.])), "pad pixels should move origin")
+        self.assertTrue(np.all(window2.pixel_shape.detach().cpu().numpy() == np.array([100, 110])), "pad pixels should change shape")
+        
     def test_window_get_indices(self):
 
         window1 = ap.image.Window(origin = (0, 6), pixel_shape = (100, 110))
@@ -312,263 +324,6 @@ class TestWindow(unittest.TestCase):
             "logical and of images should take overlap region, equality should be internally determined",
         )
 
-    # def test_window_buffering(self):
-
-    #     window = ap.image.Window(origin = (0, 0), shape = (100, 110))
-
-        # Multiply
-        ######################################################################
-        # window_scaled = window * 2
-        # self.assertEqual(
-        #     window_scaled.origin[0], -50, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[0], 200, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.origin[1], -55, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[1], 220, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window scaling should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window scaling should not affect initial images"
-        # )
-        # window_scaled = window * (2, 1)
-        # self.assertEqual(
-        #     window_scaled.origin[0], -50, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[0], 200, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.origin[1], 0, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[1], 110, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window scaling should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window scaling should not affect initial images"
-        # )
-
-        # Divide
-        ######################################################################
-        # window_scaled = window / 2
-        # self.assertEqual(
-        #     window_scaled.origin[0], 25, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[0], 50, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.origin[1], 27.5, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[1], 55, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window scaling should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window scaling should not affect initial images"
-        # )
-        # window_scaled = window / (2, 1)
-        # self.assertEqual(
-        #     window_scaled.origin[0], 25, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[0], 50, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.origin[1], 0, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_scaled.shape[1], 110, "Window scaling should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window scaling should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window scaling should not affect initial images"
-        # )
-
-        # Add
-        ######################################################################
-        # window_buffer = window + 10
-        # self.assertEqual(
-        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], -10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 130, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-        # window_buffer = window + (10.0, 5.0)
-        # self.assertEqual(
-        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], -5, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 120, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-
-        # Subtract
-        ######################################################################
-        # window_buffer = window - 10
-        # self.assertEqual(
-        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], 10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 90, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-        # window_buffer = window - (10.0, 5.0)
-        # self.assertEqual(
-        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], 5, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 100, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-
-        # iAdd
-        ######################################################################
-        # window_buffer = window.copy()
-        # window_buffer += 10
-        # self.assertEqual(
-        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], -10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 130, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-        # window_buffer = window.copy()
-        # window_buffer += (10.0, 5.0)
-        # self.assertEqual(
-        #     window_buffer.origin[0], -10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 120, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], -5, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 120, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-
-        # iSubtract
-        ######################################################################
-        # window_buffer = window.copy()
-        # window_buffer -= 10
-        # self.assertEqual(
-        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], 10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 90, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-        # window_buffer = window.copy()
-        # window_buffer -= (10.0, 5.0)
-        # self.assertEqual(
-        #     window_buffer.origin[0], 10, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[0], 80, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.origin[1], 5, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window_buffer.shape[1], 100, "Window buffer should remain centered"
-        # )
-        # self.assertEqual(
-        #     window.origin[0], 0, "Window buffering should not affect initial images"
-        # )
-        # self.assertEqual(
-        #     window.shape[0], 100, "Window buffering should not affect initial images"
-        # )
-
-        # window.shift_origin(torch.tensor(1.0))
-        # self.assertEqual(window.origin[0].item(), 1.0, "Origin should be moved")
-
     def test_window_state(self):
         window_init = ap.image.Window(origin = [1.0, 2.0], pixel_shape = [10, 15], pixelscale = 1, projection = "orthographic", reference_radec = (0,0))
         window = ap.image.Window(state=window_init.get_state())
@@ -611,18 +366,6 @@ class TestWindow(unittest.TestCase):
         self.assertNotEqual(
             window1, window3, "Differnt windows should not evaluate equal"
         )
-        # self.assertTrue(
-        #     window3 > window1, "Window3 should be identified as larger than window1"
-        # )
-        # self.assertTrue(
-        #     window3 >= window1, "Window3 should be identified as larger than window1"
-        # )
-        # self.assertTrue(
-        #     window1 < window3, "Window1 should be identified as smaller than window3"
-        # )
-        # self.assertTrue(
-        #     window1 <= window3, "Window1 should be identified as smaller than window3"
-        # )
 
 
 if __name__ == "__main__":

--- a/tests/test_window_list.py
+++ b/tests/test_window_list.py
@@ -13,8 +13,8 @@ import torch
 class TestWindowList(unittest.TestCase):
     def test_windowlist_creation(self):
 
-        window1 = ap.image.Window((0, 6), (100, 110))
-        window2 = ap.image.Window((0, 6), (100, 110))
+        window1 = ap.image.Window(origin=(0, 6), shape=(100, 110))
+        window2 = ap.image.Window(origin=(0, 6), shape=(100, 110))
         windowlist = ap.image.Window_List([window1, window2])
 
         windowlist.to(dtype=torch.float64, device="cpu")
@@ -33,8 +33,8 @@ class TestWindowList(unittest.TestCase):
 
     def test_window_arithmetic(self):
 
-        windowbig = ap.image.Window((0, 0), (100, 110))
-        windowsmall = ap.image.Window((40, 40), (20, 30))
+        windowbig = ap.image.Window(origin=(0, 0), shape=(100, 110))
+        windowsmall = ap.image.Window(origin=(40, 40), shape=(20, 30))
         windowlistbs = ap.image.Window_List([windowbig, windowsmall])
         windowlistbb = ap.image.Window_List([windowbig, windowbig])
         windowlistsb = ap.image.Window_List([windowsmall, windowbig])
@@ -120,7 +120,7 @@ class TestWindowList(unittest.TestCase):
 
         # Logical or, offset
         ######################################################################
-        windowoffset = ap.image.Window((40, -20), (100, 90))
+        windowoffset = ap.image.Window(origin=(40, -20), shape=(100, 90))
         windowlistoffset = ap.image.Window_List([windowoffset, windowoffset])
         big_or_offset = windowlistbb | windowlistoffset
         self.assertEqual(
@@ -243,7 +243,7 @@ class TestWindowList(unittest.TestCase):
 
     def test_windowlist_buffering(self):
 
-        subwindow = ap.image.Window((0, 0), (100, 110))
+        subwindow = ap.image.Window(origin=(0, 0), shape=(100, 110))
         window = ap.image.Window_List([subwindow, subwindow.copy()])
 
         # Multiply

--- a/tests/test_window_list.py
+++ b/tests/test_window_list.py
@@ -13,8 +13,8 @@ import torch
 class TestWindowList(unittest.TestCase):
     def test_windowlist_creation(self):
 
-        window1 = ap.image.Window(origin=(0, 6), shape=(100, 110))
-        window2 = ap.image.Window(origin=(0, 6), shape=(100, 110))
+        window1 = ap.image.Window(origin=(0, 6), pixel_shape=(100, 110))
+        window2 = ap.image.Window(origin=(0, 6), pixel_shape=(100, 110))
         windowlist = ap.image.Window_List([window1, window2])
 
         windowlist.to(dtype=torch.float64, device="cpu")
@@ -33,8 +33,8 @@ class TestWindowList(unittest.TestCase):
 
     def test_window_arithmetic(self):
 
-        windowbig = ap.image.Window(origin=(0, 0), shape=(100, 110))
-        windowsmall = ap.image.Window(origin=(40, 40), shape=(20, 30))
+        windowbig = ap.image.Window(origin=(0, 0), pixel_shape=(100, 110))
+        windowsmall = ap.image.Window(origin=(40, 40), pixel_shape=(20, 30))
         windowlistbs = ap.image.Window_List([windowbig, windowsmall])
         windowlistbb = ap.image.Window_List([windowbig, windowbig])
         windowlistsb = ap.image.Window_List([windowsmall, windowbig])
@@ -120,7 +120,7 @@ class TestWindowList(unittest.TestCase):
 
         # Logical or, offset
         ######################################################################
-        windowoffset = ap.image.Window(origin=(40, -20), shape=(100, 90))
+        windowoffset = ap.image.Window(origin=(40, -20), pixel_shape=(100, 90))
         windowlistoffset = ap.image.Window_List([windowoffset, windowoffset])
         big_or_offset = windowlistbb | windowlistoffset
         self.assertEqual(
@@ -241,152 +241,152 @@ class TestWindowList(unittest.TestCase):
 
         # self.assertEqual(windowbig, windowsmall, "logical and of images should take overlap region, equality should be internally determined")
 
-    def test_windowlist_buffering(self):
+    # def test_windowlist_buffering(self):
 
-        subwindow = ap.image.Window(origin=(0, 0), shape=(100, 110))
-        window = ap.image.Window_List([subwindow, subwindow.copy()])
+    #     subwindow = ap.image.Window(origin=(0, 0), pixel_shape=(100, 110))
+    #     window = ap.image.Window_List([subwindow, subwindow.copy()])
 
-        # Multiply
-        ######################################################################
-        window_scaled = window * 2
-        self.assertEqual(
-            window_scaled.origin[0][0], -50, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[0][0], 200, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.origin[0][1], -55, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[1][1], 220, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0][0], 0, "Window scaling should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[1][0], 100, "Window scaling should not affect initial images"
-        )
+    #     # Multiply
+    #     ######################################################################
+    #     window_scaled = window * 2
+    #     self.assertEqual(
+    #         window_scaled.origin[0][0], -50, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_scaled.shape[0][0], 200, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_scaled.origin[0][1], -55, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_scaled.shape[1][1], 220, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window.origin[0][0], 0, "Window scaling should not affect initial images"
+    #     )
+    #     self.assertEqual(
+    #         window.shape[1][0], 100, "Window scaling should not affect initial images"
+    #     )
 
-        # Divide
-        ######################################################################
-        window_scaled = window / 2
-        self.assertEqual(
-            window_scaled.origin[0][0], 25, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[0][0], 50, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.origin[1][1], 27.5, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window_scaled.shape[0][1], 55, "Window scaling should remain centered"
-        )
-        self.assertEqual(
-            window.origin[1][0], 0, "Window scaling should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[1][0], 100, "Window scaling should not affect initial images"
-        )
+    #     # Divide
+    #     ######################################################################
+    #     window_scaled = window / 2
+    #     self.assertEqual(
+    #         window_scaled.origin[0][0], 25, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_scaled.shape[0][0], 50, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_scaled.origin[1][1], 27.5, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_scaled.shape[0][1], 55, "Window scaling should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window.origin[1][0], 0, "Window scaling should not affect initial images"
+    #     )
+    #     self.assertEqual(
+    #         window.shape[1][0], 100, "Window scaling should not affect initial images"
+    #     )
 
-        # Add
-        ######################################################################
-        window_buffer = window + 10
-        self.assertEqual(
-            window_buffer.origin[1][0], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0][0], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1][1], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1][1], 130, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[1][0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[1][0], 100, "Window buffering should not affect initial images"
-        )
+    #     # Add
+    #     ######################################################################
+    #     window_buffer = window + 10
+    #     self.assertEqual(
+    #         window_buffer.origin[1][0], -10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[0][0], 120, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.origin[1][1], -10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[1][1], 130, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window.origin[1][0], 0, "Window buffering should not affect initial images"
+    #     )
+    #     self.assertEqual(
+    #         window.shape[1][0], 100, "Window buffering should not affect initial images"
+    #     )
 
-        # Subtract
-        ######################################################################
-        window_buffer = window - 10
-        self.assertEqual(
-            window_buffer.origin[0][0], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0][0], 80, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[0][1], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0][1], 90, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0][0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0][0], 100, "Window buffering should not affect initial images"
-        )
+    #     # Subtract
+    #     ######################################################################
+    #     window_buffer = window - 10
+    #     self.assertEqual(
+    #         window_buffer.origin[0][0], 10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[0][0], 80, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.origin[0][1], 10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[0][1], 90, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window.origin[0][0], 0, "Window buffering should not affect initial images"
+    #     )
+    #     self.assertEqual(
+    #         window.shape[0][0], 100, "Window buffering should not affect initial images"
+    #     )
 
-        # iAdd
-        ######################################################################
-        window_buffer = window.copy()
-        window_buffer += 10
-        self.assertEqual(
-            window_buffer.origin[0][0], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0][0], 120, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[1][1], -10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1][1], 130, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0][0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0][0], 100, "Window buffering should not affect initial images"
-        )
+    #     # iAdd
+    #     ######################################################################
+    #     window_buffer = window.copy()
+    #     window_buffer += 10
+    #     self.assertEqual(
+    #         window_buffer.origin[0][0], -10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[0][0], 120, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.origin[1][1], -10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[1][1], 130, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window.origin[0][0], 0, "Window buffering should not affect initial images"
+    #     )
+    #     self.assertEqual(
+    #         window.shape[0][0], 100, "Window buffering should not affect initial images"
+    #     )
 
-        # iSubtract
-        ######################################################################
-        window_buffer = window.copy()
-        window_buffer -= 10
-        self.assertEqual(
-            window_buffer.origin[1][0], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[1][0], 80, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.origin[0][1], 10, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window_buffer.shape[0][1], 90, "Window buffer should remain centered"
-        )
-        self.assertEqual(
-            window.origin[0][0], 0, "Window buffering should not affect initial images"
-        )
-        self.assertEqual(
-            window.shape[0][0], 100, "Window buffering should not affect initial images"
-        )
+    #     # iSubtract
+    #     ######################################################################
+    #     window_buffer = window.copy()
+    #     window_buffer -= 10
+    #     self.assertEqual(
+    #         window_buffer.origin[1][0], 10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[1][0], 80, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.origin[0][1], 10, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window_buffer.shape[0][1], 90, "Window buffer should remain centered"
+    #     )
+    #     self.assertEqual(
+    #         window.origin[0][0], 0, "Window buffering should not affect initial images"
+    #     )
+    #     self.assertEqual(
+    #         window.shape[0][0], 100, "Window buffering should not affect initial images"
+    #     )
 
-        self.assertRaises(NotImplementedError, window.shift_origin, torch.tensor([1.0, 1.0]))
+    #     self.assertRaises(NotImplementedError, window.shift_origin, torch.tensor([1.0, 1.0]))
 
     def test_windowlist_logic(self):
 
-        window1 = ap.image.Window(origin=[0.0, 1.0], shape=[10.2, 11.8])
-        window2 = ap.image.Window(origin=[0.0, 1.0], shape=[10.2, 11.8])
-        window3 = ap.image.Window(origin=[-0.6, 0.4], shape=[15.2, 18.0])
+        window1 = ap.image.Window(origin=[0.0, 1.0], pixel_shape=[10.2, 11.8])
+        window2 = ap.image.Window(origin=[0.0, 1.0], pixel_shape=[10.2, 11.8])
+        window3 = ap.image.Window(origin=[-0.6, 0.4], pixel_shape=[15.2, 18.0])
         windowlist1 = ap.image.Window_List([window1, window1.copy()])
         windowlist2 = ap.image.Window_List([window2, window2.copy()])
         windowlist3 = ap.image.Window_List([window3, window3.copy()])
@@ -397,22 +397,22 @@ class TestWindowList(unittest.TestCase):
         self.assertNotEqual(
             windowlist1, windowlist3, "Differnt windows should not evaluate equal"
         )
-        self.assertTrue(
-            windowlist3 > windowlist1,
-            "Window3 should be identified as larger than window1",
-        )
-        self.assertTrue(
-            windowlist3 >= windowlist1,
-            "Window3 should be identified as larger than window1",
-        )
-        self.assertTrue(
-            windowlist1 < windowlist3,
-            "Window1 should be identified as smaller than window3",
-        )
-        self.assertTrue(
-            windowlist1 <= windowlist3,
-            "Window1 should be identified as smaller than window3",
-        )
+        # self.assertTrue(
+        #     windowlist3 > windowlist1,
+        #     "Window3 should be identified as larger than window1",
+        # )
+        # self.assertTrue(
+        #     windowlist3 >= windowlist1,
+        #     "Window3 should be identified as larger than window1",
+        # )
+        # self.assertTrue(
+        #     windowlist1 < windowlist3,
+        #     "Window1 should be identified as smaller than window3",
+        # )
+        # self.assertTrue(
+        #     windowlist1 <= windowlist3,
+        #     "Window1 should be identified as smaller than window3",
+        # )
 
 
 if __name__ == "__main__":

--- a/tests/test_window_list.py
+++ b/tests/test_window_list.py
@@ -7,8 +7,6 @@ import torch
 ######################################################################
 # Window List Object
 ######################################################################
-# fixme window list origin/shape definition may need to change
-
 
 class TestWindowList(unittest.TestCase):
     def test_windowlist_creation(self):
@@ -20,12 +18,12 @@ class TestWindowList(unittest.TestCase):
         windowlist.to(dtype=torch.float64, device="cpu")
 
         # under review
-        # self.assertEqual(windowlist.origin[0], 0, "Window should store origin")
-        # self.assertEqual(windowlist.origin[1], 6, "Window should store origin")
-        # self.assertEqual(windowlist.shape[0], 100, "Window should store shape")
-        # self.assertEqual(windowlist.shape[1], 110, "Window should store shape")
-        # self.assertEqual(windowlist.center[0], 50., "Window should determine center")
-        # self.assertEqual(windowlist.center[1], 61., "Window should determine center")
+        self.assertEqual(windowlist.origin[0][0], 0, "Window list should capture origin")
+        self.assertEqual(windowlist.origin[1][1], 6, "Window list should capture origin")
+        self.assertEqual(windowlist.shape[0][0], 100, "Window list should capture shape")
+        self.assertEqual(windowlist.shape[1][1], 110, "Window list should capture shape")
+        self.assertEqual(windowlist.center[1][0], 50., "Window should determine center")
+        self.assertEqual(windowlist.center[0][1], 61., "Window should determine center")
 
         self.assertRaises(AssertionError, ap.image.Window_List)
 
@@ -208,180 +206,6 @@ class TestWindowList(unittest.TestCase):
             "logical and of images should not affect initial images",
         )
 
-        # # Logical ior, size
-        # ######################################################################
-        # windowbig |= windowsmall
-        # self.assertEqual(windowbig.origin[0], 0, "logical or of images should take largest bounding box")
-        # self.assertEqual(windowbig.shape[0], 100, "logical or of images should take largest bounding box")
-        # self.assertEqual(windowsmall.origin[0], 40, "logical or of images should not affect input image")
-        # self.assertEqual(windowsmall.shape[0], 20, "logical or of images should not affect input image")
-
-        # # Logical ior, offset
-        # ######################################################################
-        # windowbig |= windowoffset
-        # self.assertEqual(windowbig.origin[0], 0, "logical or of images should take largest bounding box")
-        # self.assertEqual(windowbig.origin[1], -20, "logical or of images should take largest bounding box")
-        # self.assertEqual(windowbig.shape[0], 140, "logical or of images should take largest bounding box")
-        # self.assertEqual(windowbig.shape[1], 130, "logical or of images should take largest bounding box")
-        # self.assertEqual(windowoffset.origin[0], 40, "logical or of images should not affect input image")
-        # self.assertEqual(windowoffset.shape[0], 100, "logical or of images should not affect input image")
-
-        # # Logical iand, offset
-        # ######################################################################
-        # windowbig = ap.image.Window((0,0), (100,110))
-        # windowbig &= windowoffset
-        # self.assertEqual(windowbig.origin[0], 40, "logical and of images should take overlap region")
-        # self.assertEqual(windowbig.origin[1], 0, "logical and of images should take overlap region")
-        # self.assertEqual(windowbig.shape[0], 60, "logical and of images should take overlap region")
-        # self.assertEqual(windowbig.shape[1], 70, "logical and of images should take overlap region")
-        # self.assertEqual(windowoffset.origin[0], 40, "logical and of images should not affect input image")
-        # self.assertEqual(windowoffset.shape[0], 100, "logical and of images should not affect input image")
-
-        # windowbig &= windowsmall
-
-        # self.assertEqual(windowbig, windowsmall, "logical and of images should take overlap region, equality should be internally determined")
-
-    # def test_windowlist_buffering(self):
-
-    #     subwindow = ap.image.Window(origin=(0, 0), pixel_shape=(100, 110))
-    #     window = ap.image.Window_List([subwindow, subwindow.copy()])
-
-    #     # Multiply
-    #     ######################################################################
-    #     window_scaled = window * 2
-    #     self.assertEqual(
-    #         window_scaled.origin[0][0], -50, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_scaled.shape[0][0], 200, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_scaled.origin[0][1], -55, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_scaled.shape[1][1], 220, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window.origin[0][0], 0, "Window scaling should not affect initial images"
-    #     )
-    #     self.assertEqual(
-    #         window.shape[1][0], 100, "Window scaling should not affect initial images"
-    #     )
-
-    #     # Divide
-    #     ######################################################################
-    #     window_scaled = window / 2
-    #     self.assertEqual(
-    #         window_scaled.origin[0][0], 25, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_scaled.shape[0][0], 50, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_scaled.origin[1][1], 27.5, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_scaled.shape[0][1], 55, "Window scaling should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window.origin[1][0], 0, "Window scaling should not affect initial images"
-    #     )
-    #     self.assertEqual(
-    #         window.shape[1][0], 100, "Window scaling should not affect initial images"
-    #     )
-
-    #     # Add
-    #     ######################################################################
-    #     window_buffer = window + 10
-    #     self.assertEqual(
-    #         window_buffer.origin[1][0], -10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[0][0], 120, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.origin[1][1], -10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[1][1], 130, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window.origin[1][0], 0, "Window buffering should not affect initial images"
-    #     )
-    #     self.assertEqual(
-    #         window.shape[1][0], 100, "Window buffering should not affect initial images"
-    #     )
-
-    #     # Subtract
-    #     ######################################################################
-    #     window_buffer = window - 10
-    #     self.assertEqual(
-    #         window_buffer.origin[0][0], 10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[0][0], 80, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.origin[0][1], 10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[0][1], 90, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window.origin[0][0], 0, "Window buffering should not affect initial images"
-    #     )
-    #     self.assertEqual(
-    #         window.shape[0][0], 100, "Window buffering should not affect initial images"
-    #     )
-
-    #     # iAdd
-    #     ######################################################################
-    #     window_buffer = window.copy()
-    #     window_buffer += 10
-    #     self.assertEqual(
-    #         window_buffer.origin[0][0], -10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[0][0], 120, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.origin[1][1], -10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[1][1], 130, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window.origin[0][0], 0, "Window buffering should not affect initial images"
-    #     )
-    #     self.assertEqual(
-    #         window.shape[0][0], 100, "Window buffering should not affect initial images"
-    #     )
-
-    #     # iSubtract
-    #     ######################################################################
-    #     window_buffer = window.copy()
-    #     window_buffer -= 10
-    #     self.assertEqual(
-    #         window_buffer.origin[1][0], 10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[1][0], 80, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.origin[0][1], 10, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window_buffer.shape[0][1], 90, "Window buffer should remain centered"
-    #     )
-    #     self.assertEqual(
-    #         window.origin[0][0], 0, "Window buffering should not affect initial images"
-    #     )
-    #     self.assertEqual(
-    #         window.shape[0][0], 100, "Window buffering should not affect initial images"
-    #     )
-
-    #     self.assertRaises(NotImplementedError, window.shift_origin, torch.tensor([1.0, 1.0]))
-
     def test_windowlist_logic(self):
 
         window1 = ap.image.Window(origin=[0.0, 1.0], pixel_shape=[10.2, 11.8])
@@ -397,23 +221,6 @@ class TestWindowList(unittest.TestCase):
         self.assertNotEqual(
             windowlist1, windowlist3, "Differnt windows should not evaluate equal"
         )
-        # self.assertTrue(
-        #     windowlist3 > windowlist1,
-        #     "Window3 should be identified as larger than window1",
-        # )
-        # self.assertTrue(
-        #     windowlist3 >= windowlist1,
-        #     "Window3 should be identified as larger than window1",
-        # )
-        # self.assertTrue(
-        #     windowlist1 < windowlist3,
-        #     "Window1 should be identified as smaller than window3",
-        # )
-        # self.assertTrue(
-        #     windowlist1 <= windowlist3,
-        #     "Window1 should be identified as smaller than window3",
-        # )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_window_list.py
+++ b/tests/test_window_list.py
@@ -28,6 +28,7 @@ class TestWindowList(unittest.TestCase):
         self.assertRaises(AssertionError, ap.image.Window_List)
 
         x = str(windowlist)
+        x = repr(windowlist)
 
     def test_window_arithmetic(self):
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,28 @@
 import torch
 import numpy as np
 import astrophot as ap
+from astropy.wcs import WCS
+
+def get_astropy_wcs():
+    hdr = {
+        "SIMPLE": "T",
+        "NAXIS": 2,
+        "NAXIS1": 180,
+        "NAXIS2": 180,
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 195.0588,
+        "CRVAL2": 28.0608,
+        "CRPIX1": 90.5,
+        "CRPIX2": 90.5,
+        "CD1_1": -0.000416666666666667,
+        "CD1_2": 0.,
+        "CD2_1": 0.,
+        "CD2_2": 0.000416666666666667,
+        "IMAGEW": 180.,
+        "IMAGEH": 180.,
+    }
+    return WCS(hdr)
 
 
 def make_basic_sersic(


### PR DESCRIPTION
@wmwv identified an issue in #115 which ultimately was tracked to the way AstroPhot converts world coordinates (RA,DEC) into the tangent plane where AstroPhot does it's calculations. It turns out that to a large degree the original coordinate system was implicitly defined and the conversion between world coordinates and tangent plane coordinates only really worked on the equator. 

The new system makes explicit the position where the tangent plane and the celestial sphere (world coordinates) meet. The update also provides clear functions to map world to/from tangent plane and also tangent plane to/from world. A new `WCS` base class added for `Window` and `Image_Header` gives them the ability to call function that map world coordinates. The new class maintains a global reference (RA_0, DEC_0) so that multi-band multi-epoch images can be mapped to the same tangent plane easily.

This also comes with some nomenclature changes. The old `world_to_pixel` function(s) was pulling double duty and just causing problems so now it's `world_to_plane` and `plane_to_pixel`. Docstrings have been updated, though I may have missed some.

A docs page is added to go into more detail. This can be found at `docs/coordinates.rst` and when merged it will be a new page in the docs website. It may be beneficial to create a notebook tutorial on coordinate systems for users that care deeply about exact coordinates.

I have also updated the tutorial notebooks correspondingly at: https://github.com/Autostronomy/AstroPhot-tutorials/tree/wcsbug

This PR closes #115 and would constitute a version update breaking backwards compatibility. This will be version 0.12.0 unless I get the parameter DAG update done before we are happy with this WCS update.