### PR TITLE
more helpful str and repr for users

### DIFF
--- a/astrophot/models/core_model.py
+++ b/astrophot/models/core_model.py
@@ -321,6 +321,10 @@ class AstroPhot_Model(object):
 
     def __str__(self):
         """String representation for the model."""
+        return self.parameters.__str__()
+    
+    def __repr__(self):
+        """Detailed string representation for the model."""
         return yaml.dump(self.get_state(), indent=2)
 
     def get_state(self):

--- a/astrophot/param/base.py
+++ b/astrophot/param/base.py
@@ -101,7 +101,7 @@ class Node(ABC):
             for node in self.nodes.values():
                 if key == node.identity:
                     return node
-        raise ValueError(f"Unrecognized key for '{self}': {key}")
+        raise ValueError(f"Unrecognized key for '{self.name}': {key}")
                 
     def __contains__(self, key):
         """Check if a node has a link directly to another node. A check like

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -135,23 +135,6 @@ class TestModel(unittest.TestCase):
 
 
 class TestAllModelBasics(unittest.TestCase):
-    def test_all_model_init(self):
-
-        target = make_basic_sersic()
-        for model_type in ap.models.Component_Model.List_Model_Names(useable=True):
-            MODEL = ap.models.AstroPhot_Model(
-                name="test model",
-                model_type=model_type,
-                target=target,
-            )
-            MODEL.initialize()
-            for P in MODEL.parameter_order:
-                self.assertIsNotNone(
-                    MODEL[P].value,
-                    f"Model type {model_type} parameter {P} should not be None after initialization",
-                )
-                # perhaps add check that uncertainty is not none
-
     def test_all_model_sample(self):
 
         target = make_basic_sersic()
@@ -163,12 +146,18 @@ class TestAllModelBasics(unittest.TestCase):
                 target=target,
             )
             MODEL.initialize()
+            for P in MODEL.parameter_order:
+                self.assertIsNotNone(
+                    MODEL[P].value,
+                    f"Model type {model_type} parameter {P} should not be None after initialization",
+                )
             img = MODEL()
             self.assertTrue(
                 torch.all(torch.isfinite(img.data)),
                 "Model should evaluate a real number for the full image",
             )
-
+            self.assertIsInstance(str(MODEL), str, "String representation should return string")
+            self.assertIsInstance(repr(MODEL), str, "Repr should return string")
 
 class TestSersic(unittest.TestCase):
     def test_sersic_creation(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -29,6 +29,24 @@ class TestModel(unittest.TestCase):
 
         state = model.get_state()
 
+    def test_initialize_does_not_recurse(self):
+        "Test case for error where missing parameter name triggered print that triggered missing parameter name ..."
+        target = make_basic_sersic()
+        model = ap.models.AstroPhot_Model(
+            name="test model",
+            model_type="sersic galaxy model",
+            target=target,
+        )
+        # Define a function that accesses a parameter that doesn't exist
+        def calc(params):
+            return params["A"].value
+
+        model["center"].value = calc
+
+        with self.assertRaises(ValueError) as context:
+            model.initialize()
+        self.assertTrue(str(context.exception) == "Unrecognized key for 'center': A")
+
     def test_basic_model_methods(self):
 
         target = make_basic_sersic()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -291,8 +291,52 @@ class TestParameterVector(unittest.TestCase):
             self.assertTrue(torch.all(vec == PG.vector_values()), "representation should be reversible")
             self.assertEqual(PG.vector_values().numel(), 5, "masked values shouldn't be shown")
 
-        self.assertIsInstance(str(PG), str, "String representation should return string")
-        self.assertIsInstance(repr(PG), str, "Repr should return string")
+
+    def test_printing(self):
+
+        def node_func_sqr(P):
+            return P["test1"].value**2
+        P1 = Parameter_Node("test1", value = 0.5, uncertainty = 0.3, limits = (-1, 1), locked = False, prof = 1.)
+        P2 = Parameter_Node("test2", value = 2., uncertainty = 1., locked = False)
+        P3 = Parameter_Node("test3", value = [4.,5.], uncertainty = [5.,3.], limits = ((0., 1.), None), locked = False)
+        P4 = Parameter_Node("test4", value = P2)
+        P5 = Parameter_Node("test5", value = node_func_sqr, link = (P1,))
+        P6 = Parameter_Node("test6", value = ((5,6),(7,8)), uncertainty = 0.1 * np.zeros((2,2)), limits = (None, 10*np.ones((2,2))))
+        PG = Parameter_Node("testgroup", link = (P1, P2, P3, P4, P5, P6))
+
+        self.assertEqual(str(PG), """testgroup:
+test1: 0.5 +- 0.3 [none], limits: (-1.0, 1.0)
+test2: 2.0 +- 1.0 [none]
+test3: [4.0, 5.0] +- [5.0, 3.0] [none], limits: ([0.0, 1.0], None)
+test6: [[5.0, 6.0], [7.0, 8.0]] +- [[0.0, 0.0], [0.0, 0.0]] [none], limits: (None, [[10.0, 10.0], [10.0, 10.0]])""", "String representation should return specific string")
+
+        ref_string = """testgroup (id-140071931416000, branch node):
+  test1 (id-140071931414752): 0.5 +- 0.3 [none], limits: (-1.0, 1.0)
+  test2 (id-140071931415376): 2.0 +- 1.0 [none]
+  test3 (id-140071931415472): [4.0, 5.0] +- [5.0, 3.0] [none], limits: ([0.0, 1.0], None)
+  test4 (id-140071931414272) points to: test2 (id-140071931415376): 2.0 +- 1.0 [none]
+  test5 (id-140071931414992, function node, node_func_sqr):
+    test1 (id-140071931414752): 0.5 +- 0.3 [none], limits: (-1.0, 1.0)
+  test6 (id-140071931415616): [[5.0, 6.0], [7.0, 8.0]] +- [[0.0, 0.0], [0.0, 0.0]] [none], limits: (None, [[10.0, 10.0], [10.0, 10.0]])"""
+        # Remove ids since they change every time
+        while "(id-" in ref_string:
+            start = ref_string.find("(id-")
+            end = ref_string.find(")", start)+1
+            ref_string = ref_string[:start] + ref_string[end:]
+
+        repr_string = repr(PG)
+        # Remove ids since they change every time
+        count = 0
+        while "(id-" in repr_string:
+            start = repr_string.find("(id-")
+            end = repr_string.find(")", start)+1
+            repr_string = repr_string[:start] + repr_string[end:]
+            count += 1
+            if count > 100:
+                raise RuntimeError("infinite loop! Something very wrong with parameter repr")
+        self.assertEqual(repr_string, ref_string, "Repr should return specific string")
+
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -291,8 +291,8 @@ class TestParameterVector(unittest.TestCase):
             self.assertTrue(torch.all(vec == PG.vector_values()), "representation should be reversible")
             self.assertEqual(PG.vector_values().numel(), 5, "masked values shouldn't be shown")
 
-        S = str(PG)
-        R = repr(PG)
+        self.assertIsInstance(str(PG), str, "String representation should return string")
+        self.assertIsInstance(repr(PG), str, "Repr should return string")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
closes #128 by making str and repr print out useful parameter values in a clear format. Example str for sersic model:
```
model1:
center: [50.0, 50.0] +- 0.1 [arcsec]
q: 0.6 +- 0.03 [b/a], limits: (0.0, 1.0)
PA: 1.0471975511965976 +- 0.06 [radians], limits: (0.0, 3.141592653589793), cyclic
n: 2.0 +- 0.05 [none], limits: (0.36, 8.0)
Re: 10.0 [arcsec], limits: (0.0, None)
Ie: 1.0 [log10(flux/arcsec^2)]
```

And example repr:
```
model1 (id-140248206704112, branch node):
  center (id-140248206702048): [50.0, 50.0] +- 0.1 [arcsec]
  q (id-140248206702000): 0.6 +- 0.03 [b/a], limits: (0.0, 1.0)
  PA (id-140248206701952): 1.0471975511965976 +- 0.06 [radians], limits: (0.0, 3.141592653589793), cyclic
  n (id-140248206701904): 2.0 +- 0.05 [none], limits: (0.36, 8.0)
  Re (id-140248206701856): 10.0 [arcsec], limits: (0.0, None)
  Ie (id-140248206701808): 1.0 [log10(flux/arcsec^2)]
```

Note the indenting for the repr, this continues for each level of the graph and it useful for complex parameter DAGs