### PR TITLE
U/wmwv/test parameter uncertainty set

### DIFF
--- a/astrophot/fit/lm.py
+++ b/astrophot/fit/lm.py
@@ -459,8 +459,10 @@ class LM(BaseOptimizer):
         cov = self.covariance_matrix
         if torch.all(torch.isfinite(cov)):
             try:
-                self.model.parameters.vector_set_uncertainty = torch.sqrt(
-                    torch.abs(torch.diag(cov))
+                self.model.parameters.vector_set_uncertainty(
+                    torch.sqrt(
+                        torch.abs(torch.diag(cov))
+                    )
                 )
             except RuntimeError as e:
                 AP_config.ap_logger.warning(f"Unable to update uncertainty due to: {e}")

--- a/astrophot/models/model_object.py
+++ b/astrophot/models/model_object.py
@@ -58,7 +58,7 @@ class Component_Model(AstroPhot_Model):
 
     # Specifications for the model parameters including units, value, uncertainty, limits, locked, and cyclic
     parameter_specs = {
-        "center": {"units": "arcsec", "uncertainty": 0.1},
+        "center": {"units": "arcsec", "uncertainty": [0.1, 0.1]},
     }
     # Fixed order of parameters for all methods that interact with the list of parameters
     _parameter_order = ("center",)

--- a/astrophot/param/parameter.py
+++ b/astrophot/param/parameter.py
@@ -501,6 +501,10 @@ class Parameter_Node(Node):
         self._uncertainty = torch.as_tensor(
             unc, dtype=AP_config.ap_dtype, device=AP_config.ap_device
         )
+        # Ensure that the uncertainty tensor has the same shape as the data
+        if self.shape is not None:
+            if self._uncertainty.shape != self.shape:
+                self._uncertainty = self._uncertainty * torch.ones(self.shape, dtype = AP_config.ap_dtype, device = AP_config.ap_device)
 
     @property
     def limits(self):
@@ -589,8 +593,8 @@ class Parameter_Node(Node):
         self.units = state.get("units", None)
         self.limits = state.get("limits", (None,None))
         self.cyclic = state.get("cyclic", False)
-        self.uncertainty = state.get("uncertainty", None)
         self.value = state.get("value", None)
+        self.uncertainty = state.get("uncertainty", None)
         self.prof = state.get("prof", None)
         self.locked = save_locked
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -82,7 +82,7 @@ class TestComponentModelFits(unittest.TestCase):
             "Re": 10,
             "Ie": 1.,
             "q": 0.7,
-            "pa": np.pi / 4,
+            "PA": np.pi / 4,
         }
         expected_uncertainty = {
             "center": [0.0047, 0.0049],
@@ -90,7 +90,7 @@ class TestComponentModelFits(unittest.TestCase):
             "Re": 0.0026,
             "Ie": 0.0072,
             "q": 0.0277,
-            "pa": 0.0022,
+            "PA": 0.0022,
         }
         tar = make_basic_sersic(
             N = shape[0],
@@ -102,7 +102,7 @@ class TestComponentModelFits(unittest.TestCase):
             Re = true_params["Re"],
             Ie = true_params["Ie"],
             q = true_params["q"],
-            PA = true_params["pa"],
+            PA = true_params["PA"],
         )
 
         mod = ap.models.Sersic_Galaxy(
@@ -147,7 +147,7 @@ class TestComponentModelFits(unittest.TestCase):
             "LM should accurately recover parameters in simple cases",
         )
         self.assertAlmostEqual(
-            mod["PA"].value.item() / true_params["pa"],
+            mod["PA"].value.item() / true_params["PA"],
             1,
             delta=0.5,
             msg="LM should accurately recover parameters in simple cases",
@@ -160,13 +160,13 @@ class TestComponentModelFits(unittest.TestCase):
         )
         cov = res.covariance_matrix
         self.assertAlmostEqual(
-            mod["center"].uncertainty.item()[0],
+            mod["center"].uncertainty[0].item(),
             expected_uncertainty["center"][0],
             1,
             "LM should accurately recover parameter uncertainty in simple cases",
         )
         self.assertAlmostEqual(
-            mod["center"].uncertainty.item()[1],
+            mod["center"].uncertainty[1].item(),
             expected_uncertainty["center"][1],
             1,
             "LM should accurately recover parameter uncertainty in simple cases",
@@ -208,8 +208,8 @@ class TestComponentModelFits(unittest.TestCase):
             "LM should accurately recover parameter uncertainty in simple cases",
         )
         self.assertAlmostEqual(
-            mod["pa"].uncertainty.item(),
-            expected_uncertainty["pa"],
+            mod["PA"].uncertainty.item(),
+            expected_uncertainty["PA"],
             1,
             "LM should accurately recover parameter uncertainty in simple cases",
         )

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -77,12 +77,20 @@ class TestComponentModelFits(unittest.TestCase):
         pixelscale = 0.8
         shape = (N + 10, N)
         true_params = {
+            "center": [shape[0]*pixelscale/2 - 3.3, shape[1]*pixelscale/2 + 5.3],
             "n": 2,
             "Re": 10,
             "Ie": 1.,
-            "center": [shape[0]*pixelscale/2 - 3.3, shape[1]*pixelscale/2 + 5.3],
             "q": 0.7,
             "pa": np.pi / 4,
+        }
+        expected_uncertainty = {
+            "center": [0.0047, 0.0049],
+            "n": 0.0013,
+            "Re": 0.0026,
+            "Ie": 0.0072,
+            "q": 0.0277,
+            "pa": 0.0022,
         }
         tar = make_basic_sersic(
             N = shape[0],
@@ -149,6 +157,61 @@ class TestComponentModelFits(unittest.TestCase):
             true_params["q"],
             1,
             "LM should accurately recover parameters in simple cases",
+        )
+        cov = res.covariance_matrix
+        self.assertAlmostEqual(
+            mod["center"].uncertainty.item()[0],
+            expected_uncertainty["center"][0],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["center"].uncertainty.item()[1],
+            expected_uncertainty["center"][1],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["n"].uncertainty.item(),
+            expected_uncertainty["n"],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["Re"].uncertainty.item(),
+            expected_uncertainty["Re"],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["Ie"].uncertainty.item(),
+            expected_uncertainty["Ie"],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["q"].uncertainty.item(),
+            expected_uncertainty["q"],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["q"].uncertainty.item(),
+            expected_uncertainty["q"],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["q"].uncertainty.item(),
+            expected_uncertainty["q"],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
+        )
+        self.assertAlmostEqual(
+            mod["pa"].uncertainty.item(),
+            expected_uncertainty["pa"],
+            1,
+            "LM should accurately recover parameter uncertainty in simple cases",
         )
 
 


### PR DESCRIPTION
closes #130 fixing the bug which replaces the `set_vector_uncertainty` method instead of using it to update the uncertainties.

Also the uncertainty is now enforced at the same shape as the `value` if a shape is available.