### PR TITLE
vector functions handle empty tuples

### DIFF
--- a/astrophot/param/parameter.py
+++ b/astrophot/param/parameter.py
@@ -284,6 +284,8 @@ class Parameter_Node(Node):
         """
         uncertainty = torch.as_tensor(uncertainty, dtype = AP_config.ap_dtype, device = AP_config.ap_device)        
         if self.leaf:
+            if self._uncertainty is None:
+                self._uncertainty = torch.ones_like(self.value)
             self._uncertainty[self.mask] = uncertainty
             return
 

--- a/astrophot/param/parameter.py
+++ b/astrophot/param/parameter.py
@@ -198,6 +198,8 @@ class Parameter_Node(Node):
 
         """
         if self.leaf:
+            if self._uncertainty is None:
+                self.uncertainty = torch.ones_like(self.value)
             return self.uncertainty[self.mask].flatten()
         
         flat = self.flat(include_locked = False, include_links = False)

--- a/astrophot/param/parameter.py
+++ b/astrophot/param/parameter.py
@@ -357,7 +357,9 @@ class Parameter_Node(Node):
         for node in flat.values():
             vals.append(node.vector_transform_rep_to_val(rep[mask[:loc].sum().int():mask[:loc+node.size].sum().int()]))
             loc += node.size
-        return torch.cat(vals)
+        if len(vals) > 0:
+            return torch.cat(vals)
+        return torch.tensor((), dtype = AP_config.ap_dtype, device = AP_config.ap_device)
     
     def vector_transform_val_to_rep(self, val):
         """Used to transform between the ``vector_values`` and
@@ -397,7 +399,9 @@ class Parameter_Node(Node):
         for node in flat.values():
             reps.append(node.vector_transform_val_to_rep(val[mask[:loc].sum().int():mask[:loc+node.size].sum().int()]))
             loc += node.size
-        return torch.cat(reps)
+        if len(reps) > 0:
+            return torch.cat(reps)
+        return torch.tensor((), dtype = AP_config.ap_dtype, device = AP_config.ap_device)
         
     def _set_val_self(self, val):
         """Handles the setting of the value for a leaf node. Ensures the

--- a/astrophot/param/parameter.py
+++ b/astrophot/param/parameter.py
@@ -145,7 +145,10 @@ class Parameter_Node(Node):
             idstr = str(self.identity)
             return np.array(tuple(f"{idstr}:{i}" for i in range(self.size)))
         flat = self.flat(include_locked = False, include_links = False)
-        return np.concatenate(tuple(node.identities for node in flat.values()))
+        vec = tuple(node.identities for node in flat.values())
+        if len(vec) > 0:
+            return np.concatenate(vec)
+        return np.array(())
     
     @property
     def names(self):
@@ -162,7 +165,10 @@ class Parameter_Node(Node):
                 return np.array((self.name,))
             return np.array(tuple(f"{self.name}:{i}" for i in range(self.size)))
         flat = self.flat(include_locked = False, include_links = False)
-        return np.concatenate(tuple(node.names for node in flat.values()))
+        vec = tuple(node.names for node in flat.values())
+        if len(vec) > 0:
+            return np.concatenate(vec)
+        return np.array(())
     
     def vector_values(self):
         """The vector representation is for values which correspond to
@@ -181,7 +187,10 @@ class Parameter_Node(Node):
             return self.value[self.mask].flatten()
         
         flat = self.flat(include_locked = False, include_links = False)
-        return torch.cat(tuple(node.vector_values() for node in flat.values()))
+        vec = tuple(node.vector_values() for node in flat.values())
+        if len(vec) > 0:
+            return torch.cat(vec)
+        return torch.tensor((), dtype = AP_config.ap_dtype, device = AP_config.ap_device)
     
     def vector_uncertainty(self):
         """This returns a vector (see vector_values) with the uncertainty for
@@ -192,7 +201,10 @@ class Parameter_Node(Node):
             return self.uncertainty[self.mask].flatten()
         
         flat = self.flat(include_locked = False, include_links = False)
-        return torch.cat(tuple(node.vector_uncertainty() for node in flat.values()))
+        vec = tuple(node.vector_uncertainty() for node in flat.values())
+        if len(vec) > 0:
+            return torch.cat(vec)
+        return torch.tensor((), dtype = AP_config.ap_dtype, device = AP_config.ap_device)
 
     def vector_representation(self):
         """This returns a vector (see vector_values) with the representation
@@ -214,7 +226,10 @@ class Parameter_Node(Node):
             return self.mask.flatten()
         
         flat = self.flat(include_locked = False, include_links = False)
-        return torch.cat(tuple(node.vector_mask() for node in flat.values()))
+        vec = tuple(node.vector_mask() for node in flat.values())
+        if len(vec) > 0:
+            return torch.cat(vec)
+        return torch.tensor((), dtype = AP_config.ap_dtype, device = AP_config.ap_device)
 
     def vector_identities(self):
         """This returns a vector (see vector_values) with the identities for
@@ -224,7 +239,10 @@ class Parameter_Node(Node):
         if self.leaf:
             return self.identities[self.mask.detach().cpu().numpy()].flatten()
         flat = self.flat(include_locked = False, include_links = False)
-        return np.concatenate(tuple(node.vector_identities() for node in flat.values()))
+        vec = tuple(node.vector_identities() for node in flat.values())
+        if len(vec) > 0:
+            return np.concatenate(vec)
+        return np.array(())
 
     def vector_names(self):
         """This returns a vector (see vector_values) with the names for each
@@ -234,7 +252,10 @@ class Parameter_Node(Node):
         if self.leaf:
             return self.names[self.mask.detach().cpu().numpy()].flatten()
         flat = self.flat(include_locked = False, include_links = False)
-        return np.concatenate(tuple(node.vector_names() for node in flat.values()))
+        vec = tuple(node.vector_names() for node in flat.values())
+        if len(vec) > 0:
+            return np.concatenate(vec)
+        return np.array(())
         
     def vector_set_values(self, values):
         """This function allows one to update the full vector of values in a

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -336,7 +336,27 @@ test6: [[5.0, 6.0], [7.0, 8.0]] +- [[0.0, 0.0], [0.0, 0.0]] [none], limits: (Non
                 raise RuntimeError("infinite loop! Something very wrong with parameter repr")
         self.assertEqual(repr_string, ref_string, "Repr should return specific string")
 
-        
 
+    def test_empty_vector(self):
+        def node_func_sqr(P):
+            return P["test1"].value**2
+        P1 = Parameter_Node("test1", value = 0.5, uncertainty = 0.3, limits = (-1, 1), locked = True, prof = 1.)
+        P2 = Parameter_Node("test2", value = 2., uncertainty = 1., locked = True)
+        P3 = Parameter_Node("test3", value = [4.,5.], uncertainty = [5.,3.], limits = ((0., 1.), None), locked = True)
+        P4 = Parameter_Node("test4", value = P2)
+        P5 = Parameter_Node("test5", value = node_func_sqr, link = (P1,))
+        P6 = Parameter_Node("test6", value = ((5,6),(7,8)), uncertainty = 0.1 * np.zeros((2,2)), limits = (None, 10*np.ones((2,2))), locked = True)
+        PG = Parameter_Node("testgroup", link = (P1, P2, P3, P4, P5, P6))
+
+        self.assertEqual(PG.names.shape, (0,), "all locked parameter should have empty names")
+        self.assertEqual(PG.identities.shape,(0,), "all locked parameter should have empty identities")
+        self.assertEqual(PG.vector_names().shape, (0,), "all locked parameter should have empty names")
+        self.assertEqual(PG.vector_identities().shape,(0,), "all locked parameter should have empty identities")
+
+        self.assertEqual(PG.vector_values().shape, (0,), "all locked parameter should have empty values")
+        self.assertEqual(PG.vector_uncertainty().shape, (0,), "all locked parameter should have empty uncertainty")
+        self.assertEqual(PG.vector_mask().shape, (0,), "all locked parameter should have empty mask")
+        self.assertEqual(PG.vector_representation().shape, (0,), "all locked parameter should have empty representation")
+        
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -357,6 +357,20 @@ test6: [[5.0, 6.0], [7.0, 8.0]] +- [[0.0, 0.0], [0.0, 0.0]] [none], limits: (Non
         self.assertEqual(PG.vector_uncertainty().shape, (0,), "all locked parameter should have empty uncertainty")
         self.assertEqual(PG.vector_mask().shape, (0,), "all locked parameter should have empty mask")
         self.assertEqual(PG.vector_representation().shape, (0,), "all locked parameter should have empty representation")
+
+    def test_none_uncertainty(self):
+        
+        P1 = Parameter_Node("test1", value = 0.5, uncertainty = 0.3, limits = (-1, 1), locked = False, prof = 1.)
+        P2 = Parameter_Node("test2", value = 2., locked = True)
+        P3 = Parameter_Node("test3", value = [4.,5.], limits = ((0., 1.), None), locked = False)
+        P4 = Parameter_Node("test4", link = (P1, P2, P3))
+
+        self.assertEqual(tuple(P4.vector_uncertainty().detach().cpu().tolist()), (0.3, 1., 1.), "None uncertainty should be filled with ones")
+        
+        P3.uncertainty = None
+        P4.vector_set_uncertainty((0.1,0.1,0.1))
+        
+        self.assertEqual(tuple(P4.vector_uncertainty().detach().cpu().tolist()), (0.1, 0.1, 0.1), "None uncertainty should be filled using vector_set_uncertainty")
         
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If all the sub parameters are locked then a model may encounter an empty tuple when trying to construct the vector representation. Since torch.concatenate doesn't handle empty tuples we include a condition to return an empty tensor.