### PR TITLE
use numpy variable instead of tensor in chunk_image_jacobian

### DIFF
--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -155,9 +155,10 @@ class Window(WCS):
         
     @property
     def shape(self):
-        S1 = self.pixel_shape.to(dtype=AP_config.ap_dtype)
+        dtype, device = self.pixelscale.dtype, self.pixelscale.device
+        S1 = self.pixel_shape.to(dtype=dtype, device=device)
         S1[1] = 0.
-        S2 = self.pixel_shape.to(dtype=AP_config.ap_dtype)
+        S2 = self.pixel_shape.to(dtype=dtype, device=device)
         S2[0] = 0.
         return torch.stack((
             torch.linalg.norm(self.pixelscale @ S1),
@@ -169,7 +170,7 @@ class Window(WCS):
             self._pixel_shape = None
             return
         shape = torch.as_tensor(
-            shape, dtype=AP_config.ap_dtype, device=AP_config.ap_device
+            shape, dtype=self.pixelscale.dtype, device=self.pixelscale.device
         )
         self.pixel_shape = shape / torch.sqrt(torch.sum(self.pixelscale**2, dim = 0))
         
@@ -188,7 +189,7 @@ class Window(WCS):
         
     @property
     def end(self):
-        return self.pixel_to_plane_delta(self.pixel_shape.to(dtype=AP_config.ap_dtype))
+        return self.pixel_to_plane_delta(self.pixel_shape.to(dtype=self.pixelscale.dtype,device=self.pixelscale.device))
 
     @property
     def origin(self):
@@ -509,7 +510,7 @@ class Window(WCS):
         return self
 
     def __str__(self):
-        return f"window origin: {self.origin.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}, center: {self.center.detach().cpu().tolist()}, pixelscale: {self.pixelscale.detach().tolist()}"
+        return f"window origin: {self.origin.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}, center: {self.center.detach().cpu().tolist()}, pixelscale: {self.pixelscale.detach().cpu().tolist()}"
 
     def __repr__(self):
         return f"window pixel_shape: {self.pixel_shape.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}\n" + super().__repr__()

--- a/astrophot/models/model_object.py
+++ b/astrophot/models/model_object.py
@@ -509,7 +509,7 @@ class Component_Model(AstroPhot_Model):
 
         pixel_shape = window.pixel_shape.detach().cpu().numpy()
         Ncells = np.int64(np.round(np.ceil(pixel_shape / self.image_chunksize)))
-        cellsize = np.int64(np.round(window.pixel_shape / Ncells))
+        cellsize = np.int64(np.round(pixel_shape / Ncells))
         
         for nx in range(Ncells[0]):
             for ny in range(Ncells[1]):

--- a/tests/test_image_header.py
+++ b/tests/test_image_header.py
@@ -66,7 +66,7 @@ class TestImageHeader(unittest.TestCase):
 
         sky_coord = wcs.pixel_to_world(*wcs.wcs.crpix)
         wcs_world = torch.tensor((sky_coord.ra.deg, sky_coord.dec.deg))
-        self.assertTrue(torch.allclose(torch.tensor(wcs.wcs.crpix), H.world_to_pixel(wcs_world)), "Astropy WCS initialization should map crval crpix coordinates")
+        self.assertTrue(torch.allclose(torch.tensor(wcs.wcs.crpix, dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device), H.world_to_pixel(wcs_world)), "Astropy WCS initialization should map crval crpix coordinates")
         
         
     def test_image_header_wcs_roundtrip(self):

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -20,16 +20,16 @@ class TestWPCS(unittest.TestCase):
         )
 
         self.assertEqual(wcs_set.projection, "orthographic", "Provided projection was Orthographic")
-        self.assertTrue(torch.all(wcs_set.reference_radec == torch.tensor((90,10))), "World coordinates should be as provided")
+        self.assertTrue(torch.all(wcs_set.reference_radec == torch.tensor((90,10), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "World coordinates should be as provided")
         self.assertNotEqual(wcs_blank.projection, "orthographic", "Not all WCS objects should be updated")
-        self.assertFalse(torch.all(wcs_blank.reference_radec == torch.tensor((90,10))), "Not all WCS objects should be updated")
+        self.assertFalse(torch.all(wcs_blank.reference_radec == torch.tensor((90,10), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "Not all WCS objects should be updated")
 
         wcs_set = wcs_set.copy()
         
         self.assertEqual(wcs_set.projection, "orthographic", "Provided projection was Orthographic")
-        self.assertTrue(torch.all(wcs_set.reference_radec == torch.tensor((90,10))), "World coordinates should be as provided")
+        self.assertTrue(torch.all(wcs_set.reference_radec == torch.tensor((90,10), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "World coordinates should be as provided")
         self.assertNotEqual(wcs_blank.projection, "orthographic", "Not all WCS objects should be updated")
-        self.assertFalse(torch.all(wcs_blank.reference_radec == torch.tensor((90,10))), "Not all WCS objects should be updated")
+        self.assertFalse(torch.all(wcs_blank.reference_radec == torch.tensor((90,10), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "Not all WCS objects should be updated")
 
     def test_wpcs_round_trip(self):
 
@@ -87,16 +87,16 @@ class TestPPCS(unittest.TestCase):
         self.assertTrue(torch.allclose(wcs_set.pixelscale, torch.tensor([[-0.173205, 0.1],[0.15,0.259808]], dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "Provided pixelscale should be used")
         self.assertTrue(torch.allclose(wcs_set.reference_imageij, torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should be as provided")
         self.assertTrue(torch.allclose(wcs_set.reference_imagexy, torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should be as provided")
-        self.assertTrue(torch.allclose(wcs_set.plane_to_pixel(torch.tensor((0.12,0.45))), torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should map to pixel reference coordinates")
-        self.assertTrue(torch.allclose(wcs_set.pixel_to_plane(torch.tensor((5.,10.))), torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should map to plane reference coordinates")
+        self.assertTrue(torch.allclose(wcs_set.plane_to_pixel(torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should map to pixel reference coordinates")
+        self.assertTrue(torch.allclose(wcs_set.pixel_to_plane(torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should map to plane reference coordinates")
 
         wcs_set = wcs_set.copy()
 
         self.assertTrue(torch.allclose(wcs_set.pixelscale, torch.tensor([[-0.173205, 0.1],[0.15,0.259808]], dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "Provided pixelscale should be used")
         self.assertTrue(torch.allclose(wcs_set.reference_imageij, torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should be as provided")
         self.assertTrue(torch.allclose(wcs_set.reference_imagexy, torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should be as provided")
-        self.assertTrue(torch.allclose(wcs_set.plane_to_pixel(torch.tensor((0.12,0.45))), torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should map to pixel reference coordinates")
-        self.assertTrue(torch.allclose(wcs_set.pixel_to_plane(torch.tensor((5.,10.))), torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should map to plane reference coordinates")
+        self.assertTrue(torch.allclose(wcs_set.plane_to_pixel(torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "plane reference coordinates should map to pixel reference coordinates")
+        self.assertTrue(torch.allclose(wcs_set.pixel_to_plane(torch.tensor((5.,10.), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), torch.tensor((0.12,0.45), dtype = ap.AP_config.ap_dtype, device = ap.AP_config.ap_device)), "pixel reference coordinates should map to plane reference coordinates")
         
 
         wcs_set.pixelscale = None


### PR DESCRIPTION
Try to Close #149 by identifying where tensor/numpy are mixed causing error when tensors are on a cuda device