### PR TITLE
feat: Add minifit fitter to optimize on downsampled target

### DIFF
--- a/astrophot/__init__.py
+++ b/astrophot/__init__.py
@@ -4,6 +4,7 @@ import requests
 import torch
 from .parse_config import galfit_config, basic_config
 from . import models, image, plots, utils, fit, param, AP_config
+
 from ._version import version as VERSION  # noqa
 
 # meta data
@@ -39,9 +40,7 @@ def run_from_terminal() -> None:
         None
 
     """
-    AP_config.ap_logger.debug(
-        "running from the terminal, not sure if it will catch me."
-    )
+    AP_config.ap_logger.debug("running from the terminal, not sure if it will catch me.")
     parser = argparse.ArgumentParser(
         prog="astrophot",
         description="Fast and flexible astronomical image photometry package. For the documentation go to: https://github.com/Autostronomy/AstroPhot",

--- a/astrophot/fit/__init__.py
+++ b/astrophot/fit/__init__.py
@@ -3,6 +3,8 @@ from .lm import *
 from .oldlm import *
 from .gradient import *
 from .iterative import *
+from .minifit import *
+
 try:
     from .hmc import *
     from .nuts import *

--- a/astrophot/fit/hmc.py
+++ b/astrophot/fit/hmc.py
@@ -13,6 +13,7 @@ from pyro.infer.mcmc.adaptation import WarmupAdapter, BlockMassMatrix
 from pyro.ops.welford import WelfordCovariance
 
 from .base import BaseOptimizer
+from ..models import AstroPhot_Model
 from .. import AP_config
 
 __all__ = ["HMC"]
@@ -82,7 +83,7 @@ class HMC(BaseOptimizer):
 
     def __init__(
         self,
-        model: "AstroPhot_Model",
+        model: AstroPhot_Model,
         initial_state: Optional[Sequence] = None,
         max_iter: int = 1000,
         **kwargs

--- a/astrophot/fit/iterative.py
+++ b/astrophot/fit/iterative.py
@@ -11,6 +11,7 @@ from scipy.optimize import minimize
 from scipy.special import gammainc
 
 from .base import BaseOptimizer
+from ..models import AstroPhot_Model
 from .lm import LM
 from ..param import Param_Mask
 from .. import AP_config
@@ -43,8 +44,8 @@ class Iter(BaseOptimizer):
 
     def __init__(
         self,
-        model: "AstroPhot_Model",
-        method: "BaseOptimizer" = LM,
+        model: AstroPhot_Model,
+        method: BaseOptimizer = LM,
         initial_state: np.ndarray = None,
         max_iter: int = 100,
         method_kwargs: Dict[str, Any] = {},

--- a/astrophot/fit/lm.py
+++ b/astrophot/fit/lm.py
@@ -224,7 +224,7 @@ class LM(BaseOptimizer):
         self.L = max(1e-9, self.L / self._Ldn)
         
     @torch.no_grad()
-    def step(self, chi2):
+    def step(self, chi2) -> torch.Tensor:
         """Performs one step of the LM algorithm. Computes Jacobian, infers
         hessian and gradient, solves for step vector and iterates on
         damping parameter magnitude until a step with some improvement
@@ -333,7 +333,7 @@ class LM(BaseOptimizer):
 
     @staticmethod
     @torch.no_grad()
-    def _h(L, grad, hess):
+    def _h(L, grad, hess) -> torch.Tensor:
         I = torch.eye(len(grad), dtype=grad.dtype, device=grad.device)
 
         h = torch.linalg.solve(
@@ -344,7 +344,7 @@ class LM(BaseOptimizer):
         return h
 
     @torch.no_grad()
-    def _chi2(self, Ypred):
+    def _chi2(self, Ypred) -> torch.Tensor:
         if self.mask is None:
             return torch.sum(self.W * (self.Y - Ypred)**2) / self.ndf
         else:
@@ -352,7 +352,7 @@ class LM(BaseOptimizer):
             
 
     @torch.no_grad()
-    def update_hess_grad(self, natural = False):
+    def update_hess_grad(self, natural = False) -> None:
         """Updates the stored hessian matrix and gradient vector. This can be
         used to compute the quantities in thier natural parameter
         represntation. During normal optimization the hessian and
@@ -369,7 +369,7 @@ class LM(BaseOptimizer):
         self.grad = torch.matmul(J.T, self.W * (self.Y - Ypred))
         
     @torch.no_grad()
-    def fit(self):
+    def fit(self) -> BaseOptimizer:
         """This performs the fitting operation. It iterates the LM step
         function until convergence is reached. Includes a message
         after fitting to indicate how the fitting exited. Typically if
@@ -453,7 +453,7 @@ class LM(BaseOptimizer):
         return self._covariance_matrix
 
     @torch.no_grad()
-    def update_uncertainty(self):
+    def update_uncertainty(self) -> None:
         """Call this function after optimization to set the uncertainties for
         the parameters. This will use the diagonal of the covariance
         matrix to update the uncertainties. See the covariance_matrix

--- a/astrophot/fit/minifit.py
+++ b/astrophot/fit/minifit.py
@@ -1,0 +1,54 @@
+# Apply an optimizer toa  downsampled version of an image
+from typing import Dict, Any
+
+import numpy as np
+
+from .base import BaseOptimizer
+from ..models import AstroPhot_Model
+from .lm import LM
+from .. import AP_config
+
+__all__ = ["MiniFit"]
+
+
+class MiniFit(BaseOptimizer):
+    def __init__(
+        self,
+        model: AstroPhot_Model,
+        downsample_factor: int = 1,
+        max_pixels: int = 10000,
+        method: BaseOptimizer = LM,
+        initial_state: np.ndarray = None,
+        method_kwargs: Dict[str, Any] = {},
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        super().__init__(model, initial_state, **kwargs)
+
+        self.method = method
+        self.method_kwargs = method_kwargs
+        if "verbose" not in self.method_kwargs:
+            self.method_kwargs["verbose"] = self.verbose
+
+        self.downsample_factor = downsample_factor
+        self.max_pixels = max_pixels
+
+    def fit(self) -> BaseOptimizer:
+        initial_target = self.model.target
+        target_area = self.model.target[self.model.window]
+        while True:
+            small_target = target_area.reduce(self.downsample_factor)
+            if small_target.size < self.max_pixels:
+                break
+            self.downsample_factor += 1
+
+        if self.verbose > 0:
+            AP_config.ap_logger.info(f"Downsampling target by {self.downsample_factor}x")
+
+        self.small_target = small_target
+        self.model.target = small_target
+        res = self.method(self.model, **self.method_kwargs).fit()
+        self.model.target = initial_target
+
+        self.message = res.message
+
+        return self

--- a/astrophot/fit/nuts.py
+++ b/astrophot/fit/nuts.py
@@ -13,6 +13,7 @@ from pyro.infer.mcmc.adaptation import WarmupAdapter, BlockMassMatrix
 from pyro.ops.welford import WelfordCovariance
 
 from .base import BaseOptimizer
+from ..models import AstroPhot_Model
 from .. import AP_config
 
 __all__ = ["NUTS"]
@@ -91,7 +92,7 @@ class NUTS(BaseOptimizer):
 
     def __init__(
         self,
-        model: "AstroPhot_Model",
+        model: AstroPhot_Model,
         initial_state: Optional[Sequence] = None,
         max_iter: int = 1000,
         **kwargs

--- a/astrophot/image/image_object.py
+++ b/astrophot/image/image_object.py
@@ -10,7 +10,7 @@ from astropy.wcs import WCS as AstropyWCS
 from .window_object import Window, Window_List
 from .image_header import Image_Header
 from .. import AP_config
-from ..errors import SpecificationConflict, ConflicingWCS
+from ..errors import SpecificationConflict, ConflicingWCS, InvalidWindow
 
 __all__ = ["Image", "Image_List"]
 
@@ -34,7 +34,7 @@ class Image(object):
     def __init__(
         self,
         *,
-        data: Optional[Union[torch.Tensor]] = None,
+        data: Optional[torch.Tensor] = None,
         header: Optional[Image_Header] = None,
         wcs: Optional[AstropyWCS] = None,
         pixelscale: Optional[Union[float, torch.Tensor]] = None,
@@ -168,6 +168,16 @@ class Image(object):
             torch.Tensor: A 1D tensor of shape (2,) containing the (x, y) coordinates of the center.
         """
         return self.header.window.center
+    
+    @property
+    def size(self) -> torch.Tensor:
+        """
+        Returns the size of the image window, the number of pixels in the image.
+
+        Returns:
+            torch.Tensor: A 0D tensor containing the number of pixels.
+        """
+        return self.header.window.size
 
     @property
     def window(self):

--- a/astrophot/image/window_object.py
+++ b/astrophot/image/window_object.py
@@ -9,6 +9,7 @@ from ..errors import ConflicingWCS, SpecificationConflict
 
 __all__ = ["Window", "Window_List"]
 
+
 class Window(WCS):
     """class to define a window on the sky in coordinate space. These
     windows can undergo arithmetic and preserve logical behavior. Image
@@ -43,7 +44,7 @@ class Window(WCS):
     ``reference_imagexy`` to fix the pixel and tangent plane
     coordinates respectively to each other, any rotation or shear will
     happen about that fixed point.
-    
+
     Args:
       origin : Sequence or None, optional
           The origin of the image in the tangent plane coordinate system
@@ -99,29 +100,31 @@ class Window(WCS):
         if state is not None:
             self.set_state(state)
             return
-        
+
         # Collect the shape of the window
         if pixel_shape is not None:
             self.pixel_shape = pixel_shape
         else:
             self.pixel_shape = wcs.pixel_shape
-            
+
         # Determine relative positioning of tangent plane and pixel grid. Also world coordinates and tangent plane
         if not sum(C is not None for C in [wcs, origin_radec, center_radec, origin, center]) <= 1:
-            raise SpecificationConflict("Please provide only one reference position for the window, otherwise the placement is ambiguous")
-        
+            raise SpecificationConflict(
+                "Please provide only one reference position for the window, otherwise the placement is ambiguous"
+            )
+
         # Image coordinates provided by WCS
         if wcs is not None:
             super().__init__(wcs=wcs, **kwargs)
         # Image reference position from RA and DEC of image origin
-        elif origin_radec is not None:  
+        elif origin_radec is not None:
             # Origin given, it is reference point
             origin_radec = torch.as_tensor(
                 origin_radec, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
             kwargs["reference_radec"] = kwargs.get("reference_radec", origin_radec)
             super().__init__(**kwargs)
-            self.reference_imageij = (-0.5,-0.5)
+            self.reference_imageij = (-0.5, -0.5)
             self.reference_imagexy = self.world_to_plane(origin_radec)
         # Image reference position from RA and DEC of image center
         elif center_radec is not None:
@@ -136,77 +139,86 @@ class Window(WCS):
             self.reference_imagexy = center
         # Image reference position from tangent plane position of image origin
         elif origin is not None:
-            kwargs.update({
-                "reference_imageij": (-0.5,-0.5),
-                "reference_imagexy": origin,
-            })
+            kwargs.update(
+                {
+                    "reference_imageij": (-0.5, -0.5),
+                    "reference_imagexy": origin,
+                }
+            )
             super().__init__(**kwargs)
         # Image reference position from tangent plane position of image center
         elif center is not None:
             pix_center = self.pixel_shape.to(dtype=AP_config.ap_dtype) / 2 - 0.5
-            kwargs.update({
-                "reference_imageij": pix_center,
-                "reference_imagexy": center,                
-            })
+            kwargs.update(
+                {
+                    "reference_imageij": pix_center,
+                    "reference_imagexy": center,
+                }
+            )
             super().__init__(**kwargs)
         # Image origin assumed to be at tangent plane origin
         else:
             super().__init__(**kwargs)
-        
+
     @property
     def shape(self):
         dtype, device = self.pixelscale.dtype, self.pixelscale.device
         S1 = self.pixel_shape.to(dtype=dtype, device=device)
-        S1[1] = 0.
+        S1[1] = 0.0
         S2 = self.pixel_shape.to(dtype=dtype, device=device)
-        S2[0] = 0.
-        return torch.stack((
-            torch.linalg.norm(self.pixelscale @ S1),
-            torch.linalg.norm(self.pixelscale @ S2),
-        ))
+        S2[0] = 0.0
+        return torch.stack(
+            (
+                torch.linalg.norm(self.pixelscale @ S1),
+                torch.linalg.norm(self.pixelscale @ S2),
+            )
+        )
+
     @shape.setter
     def shape(self, shape):
         if shape is None:
             self._pixel_shape = None
             return
-        shape = torch.as_tensor(
-            shape, dtype=self.pixelscale.dtype, device=self.pixelscale.device
-        )
-        self.pixel_shape = shape / torch.sqrt(torch.sum(self.pixelscale**2, dim = 0))
-        
+        shape = torch.as_tensor(shape, dtype=self.pixelscale.dtype, device=self.pixelscale.device)
+        self.pixel_shape = shape / torch.sqrt(torch.sum(self.pixelscale**2, dim=0))
+
     @property
     def pixel_shape(self):
         return self._pixel_shape
+
     @pixel_shape.setter
     def pixel_shape(self, shape):
         if shape is None:
             self._pixel_shape = None
             return
-        self._pixel_shape = torch.as_tensor(
-            shape, device=AP_config.ap_device
+        self._pixel_shape = torch.as_tensor(shape, device=AP_config.ap_device)
+        self._pixel_shape = torch.round(self.pixel_shape).to(
+            dtype=torch.int32, device=AP_config.ap_device
         )
-        self._pixel_shape = torch.round(self.pixel_shape).to(dtype=torch.int32, device=AP_config.ap_device)
-        
+
+    @property
+    def size(self):
+        """The number of pixels in the window"""
+        return torch.prod(self.pixel_shape)
+
     @property
     def end(self):
-        return self.pixel_to_plane_delta(self.pixel_shape.to(dtype=self.pixelscale.dtype,device=self.pixelscale.device))
+        return self.pixel_to_plane_delta(
+            self.pixel_shape.to(dtype=self.pixelscale.dtype, device=self.pixelscale.device)
+        )
 
     @property
     def origin(self):
-        return self.pixel_to_plane(-0.5*torch.ones_like(self.reference_imageij))
-    
+        return self.pixel_to_plane(-0.5 * torch.ones_like(self.reference_imageij))
+
     @property
     def center(self):
         return self.origin + self.end / 2
-    
+
     def copy(self, **kwargs):
-        copy_kwargs = {
-            "pixel_shape": torch.clone(self.pixel_shape)
-        }
+        copy_kwargs = {"pixel_shape": torch.clone(self.pixel_shape)}
         copy_kwargs.update(kwargs)
-        return super().copy(
-            **copy_kwargs
-        )
+        return super().copy(**copy_kwargs)
 
     def to(self, dtype=None, device=None):
         if dtype is None:
@@ -218,8 +230,8 @@ class Window(WCS):
 
     def rescale_pixel(self, scale, **kwargs):
         return self.copy(
-            pixelscale = self.pixelscale * scale,
-            pixel_shape = self.pixel_shape / scale,
+            pixelscale=self.pixelscale * scale,
+            pixel_shape=self.pixel_shape // scale,
             reference_imageij=(self.reference_imageij + 0.5) / scale - 0.5,
             **kwargs,
         )
@@ -230,9 +242,13 @@ class Window(WCS):
         other_origin_pix = torch.round(ref_window.plane_to_pixel(obj_window.origin) + 0.5).int()
         new_origin_pix = torch.maximum(torch.zeros_like(other_origin_pix), other_origin_pix)
 
-        other_pixel_end = torch.round(ref_window.plane_to_pixel(obj_window.origin + obj_window.end) + 0.5).int()
+        other_pixel_end = torch.round(
+            ref_window.plane_to_pixel(obj_window.origin + obj_window.end) + 0.5
+        ).int()
         new_pixel_end = torch.minimum(ref_window.pixel_shape, other_pixel_end)
-        return slice(new_origin_pix[1], new_pixel_end[1]), slice(new_origin_pix[0], new_pixel_end[0])
+        return slice(new_origin_pix[1], new_pixel_end[1]), slice(
+            new_origin_pix[0], new_pixel_end[0]
+        )
 
     def get_self_indices(self, obj):
         """
@@ -241,7 +257,7 @@ class Window(WCS):
         if isinstance(obj, Window):
             return self._get_indices(self, obj)
         return self._get_indices(self, obj.window)
-    
+
     def get_other_indices(self, obj):
         """
         Return an index slicing tuple for obj corresponding to this window
@@ -273,23 +289,23 @@ class Window(WCS):
 
     def get_astropywcs(self, **kwargs):
         wargs = {
-            'NAXIS': 2,
-            'NAXIS1': self.pixel_shape[0].item(),
-            'NAXIS2': self.pixel_shape[1].item(),
-            'CTYPE1': 'RA---TAN',
-            'CTYPE2': 'DEC--TAN',
-            'CRVAL1': self.pixel_to_world(self.reference_imageij)[0].item(),
-            'CRVAL2': self.pixel_to_world(self.reference_imageij)[1].item(),
-            'CRPIX1': self.reference_imageij[0].item(),
-            'CRPIX2': self.reference_imageij[1].item(),
-            'CD1_1': self.pixelscale[0][0].item(),
-            'CD1_2': self.pixelscale[0][1].item(),
-            'CD2_1': self.pixelscale[1][0].item(),
-            'CD2_2': self.pixelscale[1][1].item(),
+            "NAXIS": 2,
+            "NAXIS1": self.pixel_shape[0].item(),
+            "NAXIS2": self.pixel_shape[1].item(),
+            "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
+            "CRVAL1": self.pixel_to_world(self.reference_imageij)[0].item(),
+            "CRVAL2": self.pixel_to_world(self.reference_imageij)[1].item(),
+            "CRPIX1": self.reference_imageij[0].item(),
+            "CRPIX2": self.reference_imageij[1].item(),
+            "CD1_1": self.pixelscale[0][0].item(),
+            "CD1_2": self.pixelscale[0][1].item(),
+            "CD2_1": self.pixelscale[1][0].item(),
+            "CD2_2": self.pixelscale[1][1].item(),
         }
         wargs.update(kwargs)
         return AstropyWCS(wargs)
-    
+
     def get_state(self):
         state = super().get_state()
         state["pixel_shape"] = self.pixel_shape.detach().cpu().tolist()
@@ -308,18 +324,16 @@ class Window(WCS):
         [crop x low, crop y low, crop x high, crop y high]
         """
         if len(pixels) == 1:
-            self.pixel_shape = self.pixel_shape - 2*pixels[0]
+            self.pixel_shape = self.pixel_shape - 2 * pixels[0]
             self.reference_imageij = self.reference_imageij - pixels[0]
         elif len(pixels) == 2:
             pix_shift = torch.as_tensor(
                 pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
-            self.pixel_shape = self.pixel_shape - 2*pix_shift
+            self.pixel_shape = self.pixel_shape - 2 * pix_shift
             self.reference_imageij = self.reference_imageij - pix_shift
         elif len(pixels) == 4:  # different crop on all sides
-            pixels = torch.as_tensor(
-                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
+            pixels = torch.as_tensor(pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device)
             self.pixel_shape = self.pixel_shape - pixels[:2] - pixels[2:]
             self.reference_imageij = self.reference_imageij - pixels[:2]
         else:
@@ -330,9 +344,9 @@ class Window(WCS):
         """
         format: [[xmin, xmax],[ymin,ymax]]
         """
-        pixels = torch.tensor(pixels,dtype=AP_config.ap_dtype, device=AP_config.ap_device)
-        self.reference_imageij = self.reference_imageij - pixels[:,0]
-        self.pixel_shape = pixels[:,1] - pixels[:,0]
+        pixels = torch.tensor(pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device)
+        self.reference_imageij = self.reference_imageij - pixels[:, 0]
+        self.pixel_shape = pixels[:, 1] - pixels[:, 0]
         return self
 
     def pad_pixel(self, pixels):
@@ -342,18 +356,16 @@ class Window(WCS):
         [pad x low, pad y low, pad x high, pad y high]
         """
         if len(pixels) == 1:
-            self.pixel_shape = self.pixel_shape + 2*pixels[0]
+            self.pixel_shape = self.pixel_shape + 2 * pixels[0]
             self.reference_imageij = self.reference_imageij + pixels[0]
         elif len(pixels) == 2:
             pix_shift = torch.as_tensor(
                 pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
             )
-            self.pixel_shape = self.pixel_shape + 2*pix_shift
+            self.pixel_shape = self.pixel_shape + 2 * pix_shift
             self.reference_imageij = self.reference_imageij + pix_shift
         elif len(pixels) == 4:  # different crop on all sides
-            pixels = torch.as_tensor(
-                pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
+            pixels = torch.as_tensor(pixels, dtype=AP_config.ap_dtype, device=AP_config.ap_device)
             self.pixel_shape = self.pixel_shape + pixels[:2] + pixels[2:]
             self.reference_imageij = self.reference_imageij + pixels[:2]
         else:
@@ -367,12 +379,8 @@ class Window(WCS):
 
         """
         pix = self.pixel_shape.to(dtype=AP_config.ap_dtype)
-        xsteps = torch.arange(
-            pix[0], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
-        ysteps = torch.arange(
-            pix[1], dtype=AP_config.ap_dtype, device=AP_config.ap_device
-        )
+        xsteps = torch.arange(pix[0], dtype=AP_config.ap_dtype, device=AP_config.ap_device)
+        ysteps = torch.arange(pix[1], dtype=AP_config.ap_dtype, device=AP_config.ap_device)
         meshx, meshy = torch.meshgrid(
             xsteps,
             ysteps,
@@ -389,16 +397,10 @@ class Window(WCS):
         """
         pix = self.pixel_shape.to(dtype=AP_config.ap_dtype)
         xsteps = (
-            torch.arange(
-                pix[0] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            - 0.5
+            torch.arange(pix[0] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device) - 0.5
         )
         ysteps = (
-            torch.arange(
-                pix[1] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device
-            )
-            - 0.5
+            torch.arange(pix[1] + 1, dtype=AP_config.ap_dtype, device=AP_config.ap_device) - 0.5
         )
         meshx, meshy = torch.meshgrid(
             xsteps,
@@ -446,15 +448,17 @@ class Window(WCS):
     # Window Comparison operators
     @torch.no_grad()
     def __eq__(self, other):
-        return torch.all(
-            self.pixel_shape == other.pixel_shape
-        ) and torch.all(
-            self.pixelscale == other.pixelscale
-        ) and (
-            self.projection == other.projection
-        ) and (
-            torch.all(self.pixel_to_plane(torch.zeros_like(self.reference_imageij)) == other.pixel_to_plane(torch.zeros_like(other.reference_imageij)))
-        ) # fixme more checks?
+        return (
+            torch.all(self.pixel_shape == other.pixel_shape)
+            and torch.all(self.pixelscale == other.pixelscale)
+            and (self.projection == other.projection)
+            and (
+                torch.all(
+                    self.pixel_to_plane(torch.zeros_like(self.reference_imageij))
+                    == other.pixel_to_plane(torch.zeros_like(other.reference_imageij))
+                )
+            )
+        )  # fixme more checks?
 
     @torch.no_grad()
     def __ne__(self, other):
@@ -467,7 +471,9 @@ class Window(WCS):
         new_origin_pix = torch.minimum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
         other_pixel_end = self.plane_to_pixel(other.origin + other.end)
-        new_pixel_end = torch.maximum(self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end)
+        new_pixel_end = torch.maximum(
+            self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end
+        )
         return self.copy(
             origin=self.pixel_to_plane(new_origin_pix),
             pixel_shape=new_pixel_end - new_origin_pix,
@@ -479,7 +485,9 @@ class Window(WCS):
         new_origin_pix = torch.minimum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
         other_pixel_end = self.plane_to_pixel(other.origin + other.end)
-        new_pixel_end = torch.maximum(self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end)
+        new_pixel_end = torch.maximum(
+            self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end
+        )
 
         self.reference_imageij = self.reference_imageij - (new_origin_pix + 0.5)
         self.pixel_shape = new_pixel_end - new_origin_pix
@@ -491,7 +499,9 @@ class Window(WCS):
         new_origin_pix = torch.maximum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
         other_pixel_end = self.plane_to_pixel(other.origin + other.end)
-        new_pixel_end = torch.minimum(self.pixel_shape.to(dtype=AP_config.ap_dtype) - 0.5, other_pixel_end)
+        new_pixel_end = torch.minimum(
+            self.pixel_shape.to(dtype=AP_config.ap_dtype) - 0.5, other_pixel_end
+        )
         return self.copy(
             origin=self.pixel_to_plane(new_origin_pix),
             pixel_shape=new_pixel_end - new_origin_pix,
@@ -503,7 +513,9 @@ class Window(WCS):
         new_origin_pix = torch.maximum(-0.5 * torch.ones_like(other_origin_pix), other_origin_pix)
 
         other_pixel_end = self.plane_to_pixel(other.origin + other.end)
-        new_pixel_end = torch.minimum(self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end)
+        new_pixel_end = torch.minimum(
+            self.pixel_shape.to(dtype=AP_config.ap_dtype), other_pixel_end
+        )
 
         self.reference_imageij = self.reference_imageij - (new_origin_pix + 0.5)
         self.pixel_shape = new_pixel_end - new_origin_pix
@@ -513,7 +525,10 @@ class Window(WCS):
         return f"window origin: {self.origin.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}, center: {self.center.detach().cpu().tolist()}, pixelscale: {self.pixelscale.detach().cpu().tolist()}"
 
     def __repr__(self):
-        return f"window pixel_shape: {self.pixel_shape.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}\n" + super().__repr__()
+        return (
+            f"window pixel_shape: {self.pixel_shape.detach().cpu().tolist()}, shape: {self.shape.detach().cpu().tolist()}\n"
+            + super().__repr__()
+        )
 
 
 class Window_List(Window):
@@ -526,28 +541,37 @@ class Window_List(Window):
             self.window_list = list(window_list)
 
         self.check_wcs()
-        
+
     def check_wcs(self):
         """Ensure the WCS systems being used by all the windows in this list
         are consistent with each other. They should all project world
         coordinates onto the same tangent plane.
 
         """
-        windows = tuple(W.reference_radec for W in filter(lambda w: w is not None, self.window_list))
+        windows = tuple(
+            W.reference_radec for W in filter(lambda w: w is not None, self.window_list)
+        )
         if len(windows) == 0:
             return
         ref = torch.stack(windows)
         if not torch.allclose(ref, ref[0]):
-            raise ConflicingWCS("Reference (world) coordinate mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            raise ConflicingWCS(
+                "Reference (world) coordinate mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means."
+            )
 
-        ref = torch.stack(tuple(W.reference_planexy for W in filter(lambda w: w is not None, self.window_list)))
+        ref = torch.stack(
+            tuple(W.reference_planexy for W in filter(lambda w: w is not None, self.window_list))
+        )
         if not torch.allclose(ref, ref[0]):
-            raise ConflicingWCS("Reference (tangent plane) coordinate mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
+            raise ConflicingWCS(
+                "Reference (tangent plane) coordinate mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means."
+            )
 
         if len(set(W.projection for W in filter(lambda w: w is not None, self.window_list))) > 1:
-            raise ConflicingWCS("Projection mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means.")
-            
-            
+            raise ConflicingWCS(
+                "Projection mismatch! All windows in Window_List are not on the same tangent plane! Likely serious coordinate mismatch problems. See the coordinates page in the documentation for what this means."
+            )
+
     @property
     @torch.no_grad()
     def origin(self):
@@ -576,7 +600,7 @@ class Window_List(Window):
             device = AP_config.ap_device
         for window in self:
             window.to(dtype, device)
-        
+
     def get_state(self):
         return list(window.get_state() for window in self)
 
@@ -623,11 +647,7 @@ class Window_List(Window):
         return (win for win in self.window_list)
 
     def __str__(self):
-        return "Window List: \n" + (
-            "\n".join(list(str(window) for window in self)) + "\n"
-        )
+        return "Window List: \n" + ("\n".join(list(str(window) for window in self)) + "\n")
 
     def __repr__(self):
-        return "Window List: \n" + (
-            "\n".join(list(repr(window) for window in self)) + "\n"
-        )
+        return "Window List: \n" + ("\n".join(list(repr(window) for window in self)) + "\n")

--- a/astrophot/models/model_object.py
+++ b/astrophot/models/model_object.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 
 from .core_model import AstroPhot_Model
 from ..image import (
+    Image,
     Model_Image,
     Window,
     PSF_Image,
@@ -243,8 +244,8 @@ class Component_Model(AstroPhot_Model):
         self,
         X: Optional[torch.Tensor] = None,
         Y: Optional[torch.Tensor] = None,
-        image: Optional["Image"] = None,
-        parameters: "Parameter_Node" = None,
+        image: Optional[Image] = None,
+        parameters: Parameter_Node = None,
         **kwargs,
     ):
         """Evaluate the model on every pixel in the given image. The
@@ -262,7 +263,7 @@ class Component_Model(AstroPhot_Model):
 
     def sample(
         self,
-        image: Optional["Image"] = None,
+        image: Optional[Image] = None,
         window: Optional[Window] = None,
         parameters: Optional[Parameter_Node] = None,
     ):

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -29,7 +29,7 @@ class TestComponentModelFits(unittest.TestCase):
             true_params[5], IXX - true_params[3], IYY - true_params[4], true_params[6]
         )
         Z0 = ap.utils.parametric_profiles.sersic_np(
-            np.sqrt(QPAXX ** 2 + QPAYY ** 2),
+            np.sqrt(QPAXX**2 + QPAYY**2),
             true_params[0],
             true_params[1],
             true_params[2],
@@ -37,7 +37,7 @@ class TestComponentModelFits(unittest.TestCase):
         tar = ap.image.Target_Image(
             data=Z0,
             pixelscale=0.8,
-            variance=np.ones(Z0.shape) * (0.1 ** 2),
+            variance=np.ones(Z0.shape) * (0.1**2),
         )
 
         mod = ap.models.Sersic_Galaxy(
@@ -77,10 +77,10 @@ class TestComponentModelFits(unittest.TestCase):
         pixelscale = 0.8
         shape = (N + 10, N)
         true_params = {
-            "center": [shape[0]*pixelscale/2 - 3.3, shape[1]*pixelscale/2 + 5.3],
+            "center": [shape[0] * pixelscale / 2 - 3.3, shape[1] * pixelscale / 2 + 5.3],
             "n": 2,
             "Re": 10,
-            "Ie": 1.,
+            "Ie": 1.0,
             "q": 0.7,
             "PA": np.pi / 4,
         }
@@ -93,16 +93,16 @@ class TestComponentModelFits(unittest.TestCase):
             "PA": 0.0022,
         }
         tar = make_basic_sersic(
-            N = shape[0],
-            M = shape[1],
-            pixelscale = pixelscale,
-            x = true_params["center"][0],
-            y = true_params["center"][1],
-            n = true_params["n"],
-            Re = true_params["Re"],
-            Ie = true_params["Ie"],
-            q = true_params["q"],
-            PA = true_params["PA"],
+            N=shape[0],
+            M=shape[1],
+            pixelscale=pixelscale,
+            x=true_params["center"][0],
+            y=true_params["center"][1],
+            n=true_params["n"],
+            Re=true_params["Re"],
+            Ie=true_params["Ie"],
+            q=true_params["q"],
+            PA=true_params["PA"],
         )
 
         mod = ap.models.Sersic_Galaxy(
@@ -115,7 +115,7 @@ class TestComponentModelFits(unittest.TestCase):
         res = ap.fit.LM(model=mod, verbose=2).fit()
 
         res.update_uncertainty()
-        
+
         self.assertAlmostEqual(
             mod["center"].value[0].item() / true_params["center"][0],
             1,
@@ -236,7 +236,7 @@ class TestGroupModelFits(unittest.TestCase):
             true_params1[6],
         )
         Z0 = ap.utils.parametric_profiles.sersic_np(
-            np.sqrt(QPAXX ** 2 + QPAYY ** 2),
+            np.sqrt(QPAXX**2 + QPAYY**2),
             true_params1[0],
             true_params1[1],
             true_params1[2],
@@ -248,7 +248,7 @@ class TestGroupModelFits(unittest.TestCase):
             true_params2[6],
         )
         Z0 += ap.utils.parametric_profiles.sersic_np(
-            np.sqrt(QPAXX ** 2 + QPAYY ** 2),
+            np.sqrt(QPAXX**2 + QPAYY**2),
             true_params2[0],
             true_params2[1],
             true_params2[2],
@@ -257,7 +257,7 @@ class TestGroupModelFits(unittest.TestCase):
         tar = ap.image.Target_Image(
             data=Z0,
             pixelscale=0.8,
-            variance=np.ones(Z0.shape) * (0.1 ** 2),
+            variance=np.ones(Z0.shape) * (0.1**2),
         )
 
         mod1 = ap.models.Sersic_Galaxy(
@@ -271,9 +271,7 @@ class TestGroupModelFits(unittest.TestCase):
             parameters={"center": {"value": [2.1 + N / 2, -3.1 + (N + 10) / 2]}},
         )
 
-        smod = ap.models.Group_Model(
-            name="group model", models=[mod1, mod2], target=tar
-        )
+        smod = ap.models.Group_Model(name="group model", models=[mod1, mod2], target=tar)
 
         self.assertFalse(smod.locked, "default model should not be locked")
 
@@ -317,7 +315,7 @@ class TestLM(unittest.TestCase):
             target=target,
         )
 
-        LM = ap.fit.LM(new_model, max_iter = 10)
+        LM = ap.fit.LM(new_model, max_iter=10)
 
         LM.fit()
 
@@ -335,12 +333,37 @@ class TestLM(unittest.TestCase):
                 "Ie": 1,
             },
             target=target,
-            image_chunksize = 15,
+            image_chunksize=15,
         )
 
-        LM = ap.fit.LM(new_model, max_iter = 10)
+        LM = ap.fit.LM(new_model, max_iter=10)
 
         LM.fit()
+
+
+class TestMiniFit(unittest.TestCase):
+    def test_minifit(self):
+        target = make_basic_sersic()
+        new_model = ap.models.AstroPhot_Model(
+            name="test sersic",
+            model_type="sersic galaxy model",
+            parameters={
+                "center": [20, 20],
+                "PA": 60 * np.pi / 180,
+                "q": 0.5,
+                "n": 2,
+                "Re": 5,
+                "Ie": 1,
+            },
+            target=target,
+        )
+
+        MF = ap.fit.MiniFit(
+            new_model, downsample_factor=2, method_quargs={"max_iter": 10}, verbose=1
+        )
+
+        MF.fit()
+
 
 class TestIter(unittest.TestCase):
     def test_iter_basic(self):
@@ -455,10 +478,11 @@ class TestHMC(unittest.TestCase):
             + np.random.normal(scale=0.1, size=img.shape)
             + np.random.normal(scale=np.sqrt(img) / 10)
         )
-        target.variance = torch.Tensor(0.1 ** 2 + img / 100)
+        target.variance = torch.Tensor(0.1**2 + img / 100)
 
-        HMC = ap.fit.HMC(MODEL, epsilon=1e-5, max_iter=10, warmup = 5)
+        HMC = ap.fit.HMC(MODEL, epsilon=1e-5, max_iter=10, warmup=5)
         HMC.fit()
+
 
 class TestNUTS(unittest.TestCase):
     def test_nuts_sample(self):
@@ -489,10 +513,11 @@ class TestNUTS(unittest.TestCase):
             + np.random.normal(scale=0.1, size=img.shape)
             + np.random.normal(scale=np.sqrt(img) / 10)
         )
-        target.variance = torch.Tensor(0.1 ** 2 + img / 100)
+        target.variance = torch.Tensor(0.1**2 + img / 100)
 
-        NUTS = ap.fit.NUTS(MODEL, max_iter=10, warmup = 5)
+        NUTS = ap.fit.NUTS(MODEL, max_iter=10, warmup=5)
         NUTS.fit()
+
 
 class TestMHMCMC(unittest.TestCase):
     def test_singlesersic(self):
@@ -523,7 +548,7 @@ class TestMHMCMC(unittest.TestCase):
             + np.random.normal(scale=0.1, size=img.shape)
             + np.random.normal(scale=np.sqrt(img) / 10)
         )
-        target.variance = torch.Tensor(0.1 ** 2 + img / 100)
+        target.variance = torch.Tensor(0.1**2 + img / 100)
 
         MHMCMC = ap.fit.MHMCMC(MODEL, epsilon=1e-4, max_iter=100)
         MHMCMC.fit()
@@ -533,6 +558,7 @@ class TestMHMCMC(unittest.TestCase):
             0.1,
             "MHMCMC should have nonzero acceptance for simple fits",
         )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Often an image contains far more pixels than are actually needed to optimize parameters (at least for initial parameter fitting). This fitter takes a downsampled version of the target and applies an optimizer on it.