### PR TITLE
fix: fix dtype for psf in fit files

### DIFF
--- a/docs/source/prebuilt/segmap_models_fit.py
+++ b/docs/source/prebuilt/segmap_models_fit.py
@@ -94,7 +94,7 @@ else:
 if isinstance(psf_file, str):
     print("loading psf")
     hdu = fits.open(psf_file)
-    psf_data = np.array(hdu[psf_hdu].data, dtype=bool)
+    psf_data = np.array(hdu[psf_hdu].data, dtype=np.float64)
     psf = ap.image.PSF_Image(
         data=psf_data,
         pixelscale=pixelscale,

--- a/docs/source/prebuilt/single_model_fit.py
+++ b/docs/source/prebuilt/single_model_fit.py
@@ -77,7 +77,7 @@ else:
 if isinstance(psf_file, str):
     print("loading psf")
     hdu = fits.open(psf_file)
-    psf_data = np.array(hdu[psf_hdu].data, dtype=bool)
+    psf_data = np.array(hdu[psf_hdu].data, dtype=np.float64)
     psf = ap.image.PSF_Image(
         data=psf_data,
         pixelscale=pixelscale,


### PR DESCRIPTION
The "fit something fast" files had incorrect datatypes for the psf loaders. This is now fixed