### PR TITLE
Adding deblending and segmentation capability for group models

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,7 @@ build:
   apt_packages:
     - pandoc # Specify pandoc to be installed via apt-get
     - graphviz
+    - nodejs
   jobs:
     pre_build:
       # Build docstring jupyter notebooks

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,6 +25,7 @@ build:
     - pandoc # Specify pandoc to be installed via apt-get
     - graphviz
     - nodejs
+    - npm
   jobs:
     pre_build:
       # Build docstring jupyter notebooks

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,6 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "3.12"
-    nodejs: "20"
   apt_packages:
     - pandoc # Specify pandoc to be installed via apt-get
     - graphviz

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,11 +21,10 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "3.12"
+    nodejs: "20"
   apt_packages:
     - pandoc # Specify pandoc to be installed via apt-get
     - graphviz
-    - nodejs
-    - npm
   jobs:
     pre_build:
       # Build docstring jupyter notebooks

--- a/astrophot/models/gaussian_ellipsoid.py
+++ b/astrophot/models/gaussian_ellipsoid.py
@@ -1,6 +1,5 @@
 import torch
 import numpy as np
-from torch import Tensor
 
 from .model_object import ComponentModel
 from ..utils.decorators import ignore_numpy_warnings, combine_docstrings

--- a/astrophot/models/group_model_object.py
+++ b/astrophot/models/group_model_object.py
@@ -381,9 +381,9 @@ class GroupModel(Model):
                 subsubtarget = subtarget[model.window].copy(
                     name=f"deblend_{model.name}_{subtarget.name}"
                 )
-                deblend_data = subsubtarget._data * model_image._data / subfull_model._data
-                deblend_variance = subsubtarget.variance * model_image._data / subfull_model._data
-                subsubtarget._data = deblend_data
+                deblend_data = subsubtarget.data * model_image.data / subfull_model.data
+                deblend_variance = subsubtarget.variance * model_image.data / subfull_model.data
+                subsubtarget.data = deblend_data.T
                 subsubtarget.variance = deblend_variance.T
                 deblended_images.append(subsubtarget)
         return deblended_images

--- a/astrophot/models/group_model_object.py
+++ b/astrophot/models/group_model_object.py
@@ -1,6 +1,7 @@
 from typing import Optional, Sequence, Union
 
 import torch
+import numpy as np
 from caskade import forward
 
 from .base import Model
@@ -17,7 +18,7 @@ from ..image import (
     JacobianImageList,
 )
 from .. import config
-from ..backend_obj import backend
+from ..backend_obj import backend, ArrayLike
 from ..utils.decorators import ignore_numpy_warnings
 from ..errors import InvalidTarget, InvalidWindow
 
@@ -321,3 +322,68 @@ class GroupModel(Model):
             self._window = Window(window, image=self.target)
         else:
             raise InvalidWindow(f"Unrecognized window format: {str(window)}")
+
+    def segmentation_map(self) -> ArrayLike:
+        """Generate a segmentation map for this group model. Each pixel in the
+        segmentation map is assigned an integer value corresponding to the index
+        of the sub-model that corresponds to that pixel. The pixels are assigned
+        based on "relative importance", meaning that for each pixel, the
+        sub-model which contributes the largest fraction of its own total flux to that
+        pixel is assigned to it.
+
+        Returns:
+            ArrayLike: Segmentation map with the same shape as the target image as windowed by the group model window.
+
+        """
+        subtarget = self.target[self.window]
+        if isinstance(subtarget, ImageList):
+            raise NotImplementedError(
+                "Segmentation maps are not currently supported for ImageList targets. Please apply one target at a time."
+            )
+        else:
+            seg_map = backend.zeros_like(subtarget.data, dtype=backend.int32) - 1
+            max_flux_frac = 0.0 * backend.ones_like(subtarget.data) / np.prod(subtarget.data.shape)
+            for idx, model in enumerate(self.models):
+                model_image = model()
+                model_flux_frac = backend.abs(model_image.data) / backend.sum(
+                    backend.abs(model_image.data)
+                )
+                indices = subtarget.get_indices(model.window)
+                model_flux_frac_full = backend.zeros_like(subtarget.data)
+                model_flux_frac_full = backend.fill_at_indices(
+                    model_flux_frac_full, indices, model_flux_frac
+                )
+                update_mask = model_flux_frac_full >= max_flux_frac
+                seg_map = backend.where(update_mask, idx, seg_map)
+                max_flux_frac = backend.where(update_mask, model_flux_frac_full, max_flux_frac)
+            return seg_map
+
+    def deblend(self) -> Sequence[TargetImage]:
+        """Generate deblended images for each sub-model in this group model.
+        Each deblended image contains for each pixel, the fraction of the total
+        flux at that pixel which is contributed by that sub-model.
+
+        Returns:
+            Sequence[TargetImage]: List of deblended TargetImage objects for each sub-model.
+
+        """
+        deblended_images = []
+        subtarget = self.target[self.window]
+        full_model = self()
+        if isinstance(subtarget, ImageList):
+            raise NotImplementedError(
+                "Deblending is not currently supported for ImageList targets. Please apply one target at a time."
+            )
+        else:
+            for model in self.models:
+                model_image = model()
+                subfull_model = full_model[model.window]
+                subsubtarget = subtarget[model.window].copy(
+                    name=f"deblend_{model.name}_{subtarget.name}"
+                )
+                deblend_data = subsubtarget._data * model_image._data / subfull_model._data
+                deblend_variance = subsubtarget.variance * model_image._data / subfull_model._data
+                subsubtarget._data = deblend_data
+                subsubtarget.variance = deblend_variance.T
+                deblended_images.append(subsubtarget)
+        return deblended_images

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ emcee
 graphviz
 ipywidgets
 jax
-jupyter-book
+jupyter-book<2.0
 matplotlib
 nbformat
 nbsphinx

--- a/docs/source/tutorials/GroupModels.ipynb
+++ b/docs/source/tutorials/GroupModels.ipynb
@@ -76,7 +76,7 @@
    "source": [
     "pixelscale = 0.262\n",
     "target = ap.TargetImage(\n",
-    "    data=target_data,\n",
+    "    data=target_data + 0.01,  # add fake sky level back in\n",
     "    pixelscale=pixelscale,\n",
     "    zeropoint=22.5,\n",
     "    variance=\"auto\",  # this will estimate the variance from the data\n",
@@ -191,7 +191,8 @@
    "source": [
     "# This is now a very complex model composed of 9 sub-models! In total 57 parameters!\n",
     "# Here we will limit it to 1 iteration so that it runs quickly. In general you should let it run to convergence\n",
-    "result = ap.fit.Iter(groupmodel, verbose=1, max_iter=2).fit()"
+    "result = ap.fit.Iter(groupmodel, verbose=1, max_iter=2).fit()\n",
+    "result = ap.fit.LM(groupmodel, verbose=0, max_iter=2).fit()"
    ]
   },
   {
@@ -202,7 +203,7 @@
    "source": [
     "# Now we can see what the fitting has produced\n",
     "fig10, ax10 = plt.subplots(1, 2, figsize=(16, 7))\n",
-    "ap.plots.model_image(fig10, ax10[0], groupmodel, vmax=30)\n",
+    "ap.plots.model_image(fig10, ax10[0], groupmodel, vmax=25)\n",
     "ap.plots.residual_image(fig10, ax10[1], groupmodel, normalize_residuals=True)\n",
     "plt.show()"
    ]
@@ -213,6 +214,76 @@
    "source": [
     "Which is a pretty good fit! We haven't accounted for the PSF yet, so some of the central regions are not very well fit. It is very easy to add a PSF model to AstroPhot for fitting. Check out the Basic PSF Models tutorial for more information."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Segmentation maps\n",
+    "\n",
+    "AstroPhot can produce a model based segmentation map. Essentially, once the models are fit it can compute the \"importance\" of each pixel to a given model. For each pixel and for each model it is possible to compute what fraction of the model's total flux is placed in that pixel. Whichever model assigns the highest fraction of all its flux to a given pixel, is the \"winner\" for that pixel and so the segmentation map assigns the pixel to its index. Note that this is only done at the first level of a group model, since group models can contain group models, it is possible to have a complex multi-component model still act as one index in the segmentation map. \n",
+    "\n",
+    "Also note that this means AstroPhot can perform segmentation even for images with non-zero sky levels, there is no need to do background subtraction before segmenting (though you do need to fit the models)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(groupmodel.segmentation_map().T, origin=\"lower\", cmap=\"inferno\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deblending\n",
+    "\n",
+    "AstroPhot can perform a basic deblending based on the fitted model. A new target image is created for each object which for each pixel holds the fraction of signal from the original target corresponding to the fraction of light coming from that individual model (compared to the full group model). This can create some patches of zero pixel values where the model falls to zero in its own window, or where other models are much brighter. \n",
+    "\n",
+    "Note that this works even when the sky level is not subtracted. Though for very bright sky levels, the deblended objects tend to just look like their model images.\n",
+    "\n",
+    "AstroPhot doesn't use deblending, it's forward modelling approach means that it simultaneously models all objects using a principled Gaussian (or Poisson) likelihood. That said, other analyses may make use of deblended stamps. It is also a good systematic check of the flux estimates. A flux estimate that varies wildly from the deblend total flux might be cause for concern."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subtargets = groupmodel.deblend()\n",
+    "fig, axarr = plt.subplots(2, int(np.ceil(len(subtargets) / 2)), figsize=(16, 7))\n",
+    "for i, subtarget in enumerate(subtargets):\n",
+    "    ax = axarr.flatten()[i]\n",
+    "    ap.plots.target_image(fig, ax, subtarget)\n",
+    "    ax.set_title(subtarget.name, fontsize=10)\n",
+    "    ax.axis(\"off\")\n",
+    "axarr.flatten()[-1].axis(\"off\")\n",
+    "plt.show()\n",
+    "\n",
+    "for submodel, subtarget in zip(groupmodel.models, subtargets):\n",
+    "    print(\n",
+    "        f\"{submodel.name}: total model flux = {submodel.total_flux().item():.2f} ± {submodel.total_flux_uncertainty().item():.2f}, deblend total flux = {subtarget.data.sum().item():.2f}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Observe that all the models (except the sky, which we fudged anyway) are within one sigma between the model flux and the deblended flux. This is a good sign! If there had been any major deviations that would be very suspicious."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Using fitted models, AstroPhot can quite easily produce segmentation maps and deblending images. AstroPhot does not use these itself, but they can be useful for downstream analysis.