### PR TITLE
Ensure target_image plot can handle more edge cases

### DIFF
--- a/astrophot/fit/iterative.py
+++ b/astrophot/fit/iterative.py
@@ -93,7 +93,7 @@ class Iter(BaseOptimizer):
         # Update the loss value
         if self.verbose > 0:
             config.logger.info("Update Chi^2 with new parameters")
-        self.Y = self.model(params=self.current_state)
+        self.Y = self.model()
         D = self.model.target[self.model.window].flatten("data")
         V = self.model.target[self.model.window].flatten("variance")
         M = self.model.target[self.model.window].flatten("mask")
@@ -120,7 +120,8 @@ class Iter(BaseOptimizer):
         Perform the iterative fitting process until convergence or maximum iterations reached.
         """
         self.iteration = 0
-        self.Y = self.model(params=self.current_state)
+        self.model.set_values(self.current_state)
+        self.Y = self.model()
         start_fit = time()
         try:
             while True:

--- a/astrophot/models/mixins/ferrer.py
+++ b/astrophot/models/mixins/ferrer.py
@@ -49,7 +49,7 @@ class FerrerMixin:
         },
         "beta": {
             "units": "unitless",
-            "valid": (0, 2),
+            "valid": (0, 1.9),
             "shape": (),
             "dynamic": True,
             "description": "Outer slope parameter.",
@@ -124,7 +124,7 @@ class iFerrerMixin:
         },
         "beta": {
             "units": "unitless",
-            "valid": (0, 2),
+            "valid": (0, 1.9),
             "shape": (None,),
             "dynamic": True,
             "description": "Outer slope parameter.",
@@ -203,7 +203,7 @@ class FerrerPSFMixin:
         },
         "beta": {
             "units": "unitless",
-            "valid": (0, 2),
+            "valid": (0, 1.9),
             "shape": (),
             "dynamic": True,
             "description": "Outer slope parameter.",

--- a/astrophot/models/mixins/transform.py
+++ b/astrophot/models/mixins/transform.py
@@ -264,7 +264,7 @@ class WarpMixin:
     _parameter_specs = {
         "q_R": {
             "units": "b/a",
-            "valid": (0, 1),
+            "valid": (0.1, 1),
             "shape": (None,),
             "dynamic": True,
             "description": "Array of axis ratio values for axis ratio spline",

--- a/astrophot/plots/image.py
+++ b/astrophot/plots/image.py
@@ -54,14 +54,16 @@ def target_image(fig, ax, target, window=None, **kwargs):
     dat[backend.to_numpy(target_area._mask)] = np.nan
     dat[~np.isfinite(dat)] = np.nan  # change inf to NaN for simplicity
     if np.sum(np.isfinite(dat)) < 5:
-        config.logger.warning(f"< 5 plotable pixels in target image: {target.name}. Skipping plot.")
+        config.logger.warning(
+            f"< 5 plottable pixels in target image: {target.name}. Skipping plot."
+        )
         return fig, ax
     X, Y = target_area.coordinate_corner_meshgrid()
     X = backend.to_numpy(X)
     Y = backend.to_numpy(Y)
     sky = np.nanmedian(dat)
     noise = iqr(dat[np.isfinite(dat)], rng=(16, 84)) / 2
-    if noise == 0 and kwargs.get("linear", False):
+    if noise == 0 and not kwargs.get("linear", False):
         config.logger.warning(
             f"Target image: {target.name} data likely (nearly) constant value. Forcing simple linear scale."
         )

--- a/astrophot/plots/image.py
+++ b/astrophot/plots/image.py
@@ -52,13 +52,20 @@ def target_image(fig, ax, target, window=None, **kwargs):
 
     dat = np.copy(backend.to_numpy(target_area._data))
     dat[backend.to_numpy(target_area._mask)] = np.nan
+    dat[~np.isfinite(dat)] = np.nan  # change inf to NaN for simplicity
+    if np.sum(np.isfinite(dat)) < 5:
+        config.logger.warning(f"< 5 plotable pixels in target image: {target.name}. Skipping plot.")
+        return fig, ax
     X, Y = target_area.coordinate_corner_meshgrid()
     X = backend.to_numpy(X)
     Y = backend.to_numpy(Y)
     sky = np.nanmedian(dat)
     noise = iqr(dat[np.isfinite(dat)], rng=(16, 84)) / 2
-    if noise == 0:
-        noise = np.nanstd(dat)
+    if noise == 0 and kwargs.get("linear", False):
+        config.logger.warning(
+            f"Target image: {target.name} data likely (nearly) constant value. Forcing simple linear scale."
+        )
+        kwargs["linear"] = True
 
     if kwargs.get("linear", False):
         im = ax.pcolormesh(
@@ -68,29 +75,34 @@ def target_image(fig, ax, target, window=None, **kwargs):
             cmap=cmap_grad,
         )
     else:
+        pickhist = dat <= (sky + 3 * noise)
+        if np.sum(~pickhist[np.isfinite(dat)]) > 50:  # only draw log if multiple pixels above noise
+            vmin = np.nanmin(dat)
+            vmax = sky + 3 * noise
+        else:
+            vmin = np.nanmin(dat)
+            vmax = np.nanmax(dat)
+
         im = ax.pcolormesh(
             X,
             Y,
             dat,
             cmap="gray_r",
             norm=ImageNormalize(
-                stretch=HistEqStretch(
-                    dat[np.logical_and(dat <= (sky + 3 * noise), np.isfinite(dat))]
-                ),
+                stretch=HistEqStretch(dat[np.logical_and(dat <= vmax, np.isfinite(dat))]),
                 clip=False,
-                vmax=sky + 3 * noise,
-                vmin=np.nanmin(dat),
+                vmin=vmin,
+                vmax=vmax,
             ),
         )
-        pickhist = dat < (sky + 3 * noise)
-        if np.sum(~pickhist) > 5:  # only draw log if multiple pixels above noise
+        if np.sum(~pickhist[np.isfinite(dat)]) > 50:  # only draw log if multiple pixels above noise
             im = ax.pcolormesh(
                 X,
                 Y,
                 np.ma.masked_where(pickhist, dat),
                 cmap=cmap_grad,
                 norm=matplotlib.colors.LogNorm(),
-                clim=[sky + 3 * noise, None],
+                clim=[sky + 3 * noise, np.nanmax(dat)],
             )
 
     if np.linalg.det(target.CD.npvalue) < 0:

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -19,6 +19,21 @@ def test_target_image():
     ap.plots.target_image(fig, ax, target)
     plt.close()
 
+    # Constant target does not raise
+    fig, ax = plt.subplots()
+    target = ap.TargetImage(data=np.zeros((10, 10)), name="pathological_test_target")
+    ap.plots.target_image(fig, ax, target)
+    plt.close()
+
+    # Target of non-finite values does not raise
+    fig, ax = plt.subplots()
+    data = np.full((10, 10), np.nan)
+    data[0, 0] = 1.0
+    data[5, 5] = 2.0
+    target = ap.TargetImage(data=data, name="pathological_test_target")
+    ap.plots.target_image(fig, ax, target)
+    plt.close()
+
 
 def test_psf_image():
     target = make_basic_gaussian_psf()


### PR DESCRIPTION
Some edge cases with very little data that is very noisy could cause vmin/vmax to flip and then raise an error in matplotlib. We now handle as many cases as we can and try to exit gracefully (no plotting) if a case cannot be handled.